### PR TITLE
Fix „Run” command

### DIFF
--- a/Commands/Run Script.tmCommand
+++ b/Commands/Run Script.tmCommand
@@ -12,7 +12,7 @@ require ENV["TM_SUPPORT_PATH"] + "/lib/tm/save_current_document"
 
 TextMate.save_if_untitled("swift")
 
-command = ["xcrun --sdk macosx swift -i", "#{ENV["TM_FILEPATH"]}"]
+command = ["xcrun", "--sdk", "macosx", "swift", "-i", "#{ENV["TM_FILEPATH"]}"]
 TextMate::Executor.run(command)
 </string>
 	<key>input</key>


### PR DESCRIPTION
Hi,

this should fix a bug in the „Run” command. `TextMate::Executor.run` expects all „words” in the shell command `xcrun --sdk macosx swift -i` to be a single element of an array. This commit reintroduces this behaviour, that seemed to got lost in the work done in commit b2a52fa1ff54ed9f91c86bad2affa47a80c9fa00.

Regards,
  René
