### PR TITLE
Add simple folding markers for swift

### DIFF
--- a/Preferences/Folding - TextMate Plist.tmPreferences
+++ b/Preferences/Folding - TextMate Plist.tmPreferences
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Folding</string>
+	<key>scope</key>
+	<string>source.swift</string>
+	<key>settings</key>
+	<dict>
+		<key>foldingStartMarker</key>
+		<string>\{\s*$</string>
+		<key>foldingStopMarker</key>
+		<string>^\s*\}</string>
+	</dict>
+	<key>uuid</key>
+	<string>5293C37D-4728-42F5-8219-B900CED6E358</string>
+</dict>
+</plist>


### PR DESCRIPTION
The Folding markers are based on the simple '{\s_$' and '^\s_}'
