### PR TITLE
Fix syntax hi-lighting for protocol functions

### DIFF
--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -486,13 +486,13 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>entity.type.funciton.swift</string>
+					<string>entity.type.function.swift</string>
 				</dict>
 			</dict>
 			<key>comment</key>
 			<string>function-declaration</string>
 			<key>end</key>
-			<string>(?&lt;=\})</string>
+			<string>$</string>
 			<key>name</key>
 			<string>meta.function-declaration.swift</string>
 			<key>patterns</key>
@@ -530,7 +530,7 @@
 			<key>comment</key>
 			<string>function-result</string>
 			<key>end</key>
-			<string>\s*(?=\{)</string>
+			<string>\s*$</string>
 			<key>name</key>
 			<string>meta.function-result.swift</string>
 			<key>patterns</key>


### PR DESCRIPTION
Previous matches for function declaration looked for a `func` keyword
and ended with a }. This search for a closing curly brace caused
functions declared in a protocol to have incorrect syntax hi-lighting.
I have changed the function-declaration and function-result to end at $
to correct the hi-lighting for protocols.

Also fixed a funcition typo.
