### PR TITLE
Update "Run Script.tmCommand"

### DIFF
--- a/Commands/Run Script.tmCommand
+++ b/Commands/Run Script.tmCommand
@@ -12,7 +12,7 @@ require ENV["TM_SUPPORT_PATH"] + "/lib/tm/save_current_document"
 
 TextMate.save_if_untitled("swift")
 
-command = ["xcrun", "--sdk", "macosx", "swift", "#{ENV["TM_FILEPATH"]}"]
+command = ["swift", "#{ENV["TM_FILEPATH"]}"]
 TextMate::Executor.run(command)
 </string>
 	<key>input</key>


### PR DESCRIPTION
A Swift "shebang" script would fail when using the run parameters "macosx" and "--sdk".
Also removed the "xcrun" parameter as it is no longer needed.
Modified the Run Command (command-R) to work with Swift version 1.2 and OS X Yosemite 10.10.3.