### PR TITLE
Minor fixes for Swift 1.0 & 2.0

### DIFF
--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -856,7 +856,7 @@
 					<key>comment</key>
 					<string>statement keyword</string>
 					<key>match</key>
-					<string>\b(break|case|continue|default|do|else|fallthrough|if|in|for|return|switch|where|while)\b</string>
+					<string>\b(break|case|catch|continue|default|do|else|fallthrough|guard|if|in|for|repeat|return|switch|try|throw|where|while)\b</string>
 					<key>name</key>
 					<string>keyword.control.statement.swift</string>
 				</dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -263,7 +263,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(Array|Dictionary|Set)\b</string>
+					<string>\b(Array|Dictionary)\b</string>
 					<key>name</key>
 					<string>support.type.swift</string>
 				</dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -679,7 +679,7 @@
 			<key>comment</key>
 			<string>function-result</string>
 			<key>end</key>
-			<string>\s*(?=\{)</string>
+			<string>(?=\{)|$</string>
 			<key>name</key>
 			<string>meta.function-result.swift</string>
 			<key>patterns</key>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -533,7 +533,7 @@
 			<key>comment</key>
 			<string>declaration-specifier</string>
 			<key>match</key>
-			<string>\b(class|mutating|nonmutating|override|static)\b</string>
+			<string>\b(public|internal|private|convenience|lazy|class|mutating|nonmutating|override|static)\b</string>
 			<key>name</key>
 			<string>keyword.other.declaration-specifier.swift</string>
 		</dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -533,7 +533,7 @@
 			<key>comment</key>
 			<string>declaration-specifier</string>
 			<key>match</key>
-			<string>\b(public|internal|private|convenience|lazy|class|mutating|nonmutating|override|static)\b</string>
+			<string>\b(class|deinit|enum|extension|func|import|init|inout|internal|let|operator|private|protocol|public|static|struct|subscript|typealias|var)\b</string>
 			<key>name</key>
 			<string>keyword.other.declaration-specifier.swift</string>
 		</dict>
@@ -848,7 +848,7 @@
 					<key>comment</key>
 					<string>declaration keyword</string>
 					<key>match</key>
-					<string>\b(class|deinit|enum|extension|func|import|init|let|protocol|static|struct|subscript|typealias|var)\b</string>
+					<string>\b(class|deinit|enum|extension|func|import|init|inout|internal|let|operator|private|protocol|public|static|struct|subscript|typealias|var)\b</string>
 					<key>name</key>
 					<string>storage.type.declaration.swift</string>
 				</dict>
@@ -856,7 +856,7 @@
 					<key>comment</key>
 					<string>statement keyword</string>
 					<key>match</key>
-					<string>\b(break|case|catch|continue|default|do|else|fallthrough|guard|if|in|for|repeat|return|switch|try|throw|where|while)\b</string>
+					<string>\b(break|case|continue|default|defer|do|else|fallthrough|for|guard|if|in|repeat|return|switch|where|while)\b</string>
 					<key>name</key>
 					<string>keyword.control.statement.swift</string>
 				</dict>
@@ -864,7 +864,7 @@
 					<key>comment</key>
 					<string>expression and type keyword</string>
 					<key>match</key>
-					<string>\b(as|dynamicType|is|new|super|self|Self|Type)\b</string>
+					<string>\b(as|catch|dynamicType|false|is|nil|rethrows|super|self|Self|throw|throws|true|try|__COLUMN__|__FILE__|__FUNCTION__|__LINE__)\b</string>
 					<key>name</key>
 					<string>keyword.other.statement.swift</string>
 				</dict>
@@ -872,7 +872,7 @@
 					<key>comment</key>
 					<string>other keyword</string>
 					<key>match</key>
-					<string>\b(associativity|didSet|get|infix|inout|left|mutating|none|nonmutating|operator|override|postfix|precedence|prefix|right|set|unowned((un)?safe)?|weak|willSet)\b</string>
+					<string>\b(associativity|convenience|dynamic|didSet|final|get|infix|indirect|lazy|left|mutating|none|nonmutating|optional|override|postfix|precedence|prefix|Protocol|required|right|set|Type|unowned|weak|willSet)\b</string>
 					<key>name</key>
 					<string>keyword.other.swift</string>
 				</dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -263,7 +263,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(Array|Dictionary)\b</string>
+					<string>\b(Array|Dictionary|Set)\b</string>
 					<key>name</key>
 					<string>support.type.swift</string>
 				</dict>


### PR DESCRIPTION
This adds several keywords (access modifiers, new Swift 2.0 features, etc.) that have come to Swift since the last syntax update, and fixes the problem where the formatting disappears after `foo` in this code sample:

```swift
protocol A {
    func foo(x: String) -> Int
}

let bar = "This is unformatted."
let baz = foo("So is this.")

struct B : A {
    let y = "Formatting has resumed!"

    func foo(x: String) -> Int {
        return x.characters.count
    }
}
```