### PR TITLE
Consider external parameter names to be part of the function name

### DIFF
--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -1212,6 +1212,11 @@
 				<dict>
 					<key>captures</key>
 					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.swift</string>
+						</dict>
 						<key>2</key>
 						<dict>
 							<key>name</key>


### PR DESCRIPTION
In this example, the function signature is `touchesMoved(_:withEvent:)`, so `withEvent` is also highlighted like a function name.

![screenshot](https://cloud.githubusercontent.com/assets/14237/10658447/bf21f5e2-784b-11e5-882e-5c535c9e33d6.png)
