### PR TITLE
Treat `xcrun --sdk macosx swift` as a single command

### DIFF
--- a/Commands/Run Script.tmCommand
+++ b/Commands/Run Script.tmCommand
@@ -12,7 +12,7 @@ require ENV["TM_SUPPORT_PATH"] + "/lib/tm/save_current_document"
 
 TextMate.save_if_untitled("swift")
 
-command = ["xcrun", "--sdk", "macosx", "swift", "#{ENV["TM_FILEPATH"]}"]
+command = ["#{ENV["TM_BUNDLE_SUPPORT"]}/bin/tmswift", "#{ENV["TM_FILEPATH"]}"]
 TextMate::Executor.run(command)
 </string>
 	<key>input</key>

--- a/Support/bin/tmswift
+++ b/Support/bin/tmswift
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec xcrun --sdk macosx swift "$@"


### PR DESCRIPTION
When running a script containing a correct hashbang, like

    #!/usr/bin/env xcrun --sdk macosx swift

the TextMate::Executor would replace the *first* element of `command` with the parsed hashbang command.

This results in TextMate trying to execute commands like

    /usr/bin/env xcrun --sdk macosx swift --sdk macosx swift

which fails because swift(1) doesn’t accept an `--sdk` parameter.

This change specifies the whole `xcrun … swift` command as a single element, which it is anyway conceptually, and which fixes this problem.