### PR TITLE
Remove obsolete `-i` parameter from shebang

### DIFF
--- a/Snippets/shebang env.tmSnippet
+++ b/Snippets/shebang env.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>#!/usr/bin/env xcrun --sdk macosx swift -i
+	<string>#!/usr/bin/env xcrun --sdk macosx swift
 </string>
 	<key>name</key>
 	<string>#!/usr/bin/env swift (env)</string>

--- a/Snippets/shebang.tmSnippet
+++ b/Snippets/shebang.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>#!/usr/bin/env xcrun --sdk macosx swift -i
+	<string>#!/usr/bin/env xcrun --sdk macosx swift
 </string>
 	<key>name</key>
 	<string>#!/usr/bin/env swift</string>


### PR DESCRIPTION
The `-i` flag is obsolete and generates the following error:

    error: the flag '-i' is no longer required and has been removed; use 'swift input-filename'