### PR TITLE
Major grammar improvements

### DIFF
--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -1265,34 +1265,24 @@
 		<key>declaration-type</key>
 		<dict>
 			<key>begin</key>
-			<string>\b(?:(class)|(struct)|(enum))\s+((?!\d)\w[\w\d]*\b|\B`(?!\d)\w[\w\d]*`\B)\s*(?=\{|&lt;)</string>
+			<string>\b(class|struct|enum)\s+((?!\d)\w[\w\d]*\b|\B`(?!\d)\w[\w\d]*`\B)\s*(?=[{&lt;:])</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>storage.type.class.swift</string>
+					<string>storage.type.$1.swift</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>storage.type.struct.swift</string>
-				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>storage.type.enum.swift</string>
-				</dict>
-				<key>4</key>
-				<dict>
-					<key>name</key>
-					<string>entity.name.type.swift</string>
+					<string>entity.name.type.$1.swift</string>
 				</dict>
 			</dict>
 			<key>end</key>
 			<string>(?&lt;=\})|$</string>
 			<key>name</key>
-			<string>meta.definition.type.swift</string>
+			<string>meta.definition.type.$1.swift</string>
 			<key>patterns</key>
 			<array>
 				<dict>
@@ -1308,6 +1298,10 @@
 					<string>Swift 3: generic constraints after the generic param list</string>
 					<key>include</key>
 					<string>#generic-constraints</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#inheritance-clause</string>
 				</dict>
 				<dict>
 					<key>begin</key>
@@ -1500,6 +1494,84 @@
 			<string>(?&lt;![/=\-+!*%&lt;&gt;&amp;|\^~.])(\+\+|\-\-)(?![/=\-+!*%&lt;&gt;&amp;|\^~.])</string>
 			<key>name</key>
 			<string>keyword.operator.increment-or-decrement.swift</string>
+		</dict>
+		<key>inheritance-clause</key>
+		<dict>
+			<key>begin</key>
+			<string>:\s*</string>
+			<key>end</key>
+			<string>(?=\bwhere\b|\{)</string>
+			<key>name</key>
+			<string>meta.inheritance-clause.swift</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>\b(?!\d)\w[\w\d]*\b</string>
+					<key>end</key>
+					<string>(?=\s*[^\s(&lt;])(?# this pattern may only end if what follows doesn't look like it could be a valid type)</string>
+					<key>name</key>
+					<string>entity.other.inherited-class.swift</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#nested-angles</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#type</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+			<key>repository</key>
+			<dict>
+				<key>nested-angles</key>
+				<dict>
+					<key>begin</key>
+					<string>&lt;</string>
+					<key>end</key>
+					<string>&gt;|(?=[^\w\d&lt;&gt;()\s,=&amp;`](?# damage control - characters other than these should never be allowed in an inheritance clause ))</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#type</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#nested-angles</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#nested-parens</string>
+						</dict>
+					</array>
+				</dict>
+				<key>nested-parens</key>
+				<dict>
+					<key>begin</key>
+					<string>\(</string>
+					<key>end</key>
+					<string>\)|(?=[^\w\d&lt;&gt;()\s,=&amp;`](?# damage control - characters other than these should never be allowed in an inheritance clause ))</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#type</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#nested-parens</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#nested-angles</string>
+						</dict>
+					</array>
+				</dict>
+			</dict>
 		</dict>
 		<key>keyword</key>
 		<dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -1358,7 +1358,7 @@
 		<key>declaration-type</key>
 		<dict>
 			<key>begin</key>
-			<string>\b(class|struct|enum)\s+((?!\d)\w[\w\d]*\b|\B`(?!\d)\w[\w\d]*`\B)</string>
+			<string>\b(class(?!\s+(?:func|var|let)\b)|struct|enum)\s+((?!\d)\w[\w\d]*\b|\B`(?!\d)\w[\w\d]*`\B)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -84,43 +84,6 @@
 			<key>name</key>
 			<string>keyword.operator.arithmetic.swift</string>
 		</dict>
-		<key>array-type</key>
-		<dict>
-			<key>begin</key>
-			<string>\b(Array)(\[)</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>support.type.array.swift</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.array.begin.swift</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>(\])</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.array.end.swift</string>
-				</dict>
-			</dict>
-			<key>name</key>
-			<string>meta.array.swift</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>$self</string>
-				</dict>
-			</array>
-		</dict>
 		<key>assignment-operator</key>
 		<dict>
 			<key>match</key>
@@ -210,22 +173,6 @@
 			<key>name</key>
 			<string>constant.language.boolean.swift</string>
 		</dict>
-		<key>branch-statement-keyword</key>
-		<dict>
-			<key>name</key>
-			<string>keyword.control.branch.swift</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#if-statement-keyword</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#switch-statement-keyword</string>
-				</dict>
-			</array>
-		</dict>
 		<key>builtin-class-type</key>
 		<dict>
 			<key>comment</key>
@@ -267,7 +214,7 @@
 			<key>comment</key>
 			<string>Global functions provided in the standard library; found by searching ^func\s+(\w+?)[&lt;(]</string>
 			<key>match</key>
-			<string>\b(s(tride(of(Value)?)?|izeof(Value)?|ort|uffix|pli(ce|t)|wap)|numericCast|transcode|i(sUniquelyReferenced(NonObjC)?|nsert)|zip|overlaps|d(istance|ump|ebugPrint|rop(First|Last))|unsafe(BitCast|Downcast|Unwrap|AddressOf)|join|pr(int|e(condition|fix))|extend|with(Unsafe(MutablePointer(s)?|Pointer(s)?)|ExtendedLifetime|VaList)|lazy|a(ssert(ionFailure)?|nyGenerator|dvance|lignof(Value)?|bs)|re(flect|adLine|move(Range|Last|A(tIndex|ll)))|getVaList|m(in|ax))\b</string>
+			<string>\btype(?=\(of\:)|\b(s(tride(of(Value)?)?|izeof(Value)?|ort|uffix|pli(ce|t)|wap)|numericCast|transcode|i(sUniquelyReferenced(NonObjC)?|nsert)|zip|overlaps|d(istance|ump|ebugPrint|rop(First|Last))|unsafe(BitCast|Downcast|Unwrap|AddressOf)|join|pr(int|e(condition|fix))|extend|with(Unsafe(MutablePointer(s)?|Pointer(s)?)|ExtendedLifetime|VaList)|lazy|a(ssert(ionFailure)?|nyGenerator|dvance|lignof(Value)?|bs)|re(flect|adLine|move(Range|Last|A(tIndex|ll)))|getVaList|m(in|ax))\b</string>
 			<key>name</key>
 			<string>support.function.swift</string>
 		</dict>
@@ -344,15 +291,6 @@
 			<key>name</key>
 			<string>support.type.swift</string>
 		</dict>
-		<key>capture-specifier</key>
-		<dict>
-			<key>comment</key>
-			<string>matches weak, unowned, unowned(safe), unowned(unsafe)</string>
-			<key>match</key>
-			<string>\b(weak|unowned(?:\((?:un)?safe\))?)</string>
-			<key>name</key>
-			<string>keyword.other.capture-specifier.swift</string>
-		</dict>
 		<key>coalescing-operator</key>
 		<dict>
 			<key>match</key>
@@ -389,22 +327,6 @@
 				<dict>
 					<key>include</key>
 					<string>$self</string>
-				</dict>
-			</array>
-		</dict>
-		<key>collection-type</key>
-		<dict>
-			<key>comment</key>
-			<string>Collection types</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#array-type</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#dictionary-type</string>
 				</dict>
 			</array>
 		</dict>
@@ -616,15 +538,6 @@
 			<key>name</key>
 			<string>keyword.operator.comparative.swift</string>
 		</dict>
-		<key>control-transfer-statement-keyword</key>
-		<dict>
-			<key>comment</key>
-			<string>control-transfer-statement</string>
-			<key>match</key>
-			<string>\b(continue|break|fallthrough|return)\b</string>
-			<key>name</key>
-			<string>keyword.control.transfer.swift</string>
-		</dict>
 		<key>custom-operator</key>
 		<dict>
 			<key>patterns</key>
@@ -664,52 +577,6 @@
 				<dict>
 					<key>include</key>
 					<string>#function-declaration</string>
-				</dict>
-			</array>
-		</dict>
-		<key>declaration-specifier</key>
-		<dict>
-			<key>comment</key>
-			<string>declaration-specifier</string>
-			<key>match</key>
-			<string>\b(class|deinit|enum|extension|func|import|init|inout|internal|let|operator|private|protocol|public|static|struct|subscript|typealias|var)\b</string>
-			<key>name</key>
-			<string>keyword.other.declaration-specifier.swift</string>
-		</dict>
-		<key>dictionary-type</key>
-		<dict>
-			<key>begin</key>
-			<string>\b(Dictionary)(\[)</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>support.type.dictionary.swift</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.dictionary.begin.swift</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>(\])</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.dictionary.end.swift</string>
-				</dict>
-			</dict>
-			<key>name</key>
-			<string>meta.dictionary.swift</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>$self</string>
 				</dict>
 			</array>
 		</dict>
@@ -872,15 +739,6 @@
 			<key>name</key>
 			<string>meta.identifier.swift</string>
 		</dict>
-		<key>if-statement-keyword</key>
-		<dict>
-			<key>comment</key>
-			<string>if-statement</string>
-			<key>match</key>
-			<string>\b(if|else)\b</string>
-			<key>name</key>
-			<string>keyword.control.if.swift</string>
-		</dict>
 		<key>import-declaration</key>
 		<dict>
 			<key>captures</key>
@@ -888,7 +746,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.other.import.swift</string>
+					<string>keyword.control.import.swift</string>
 				</dict>
 				<key>2</key>
 				<dict>
@@ -960,60 +818,96 @@
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>include</key>
-					<string>#branch-statement-keyword</string>
+					<key>match</key>
+					<string>\b(?:if|else|guard|where|switch|case|default|fallthrough)\b</string>
+					<key>name</key>
+					<string>keyword.control.branch.swift</string>
 				</dict>
 				<dict>
-					<key>include</key>
-					<string>#control-transfer-statement-keyword</string>
+					<key>match</key>
+					<string>\b(?:continue|break|fallthrough|return)\b</string>
+					<key>name</key>
+					<string>keyword.control.transfer.swift</string>
 				</dict>
 				<dict>
-					<key>include</key>
-					<string>#loop-statement-keyword</string>
+					<key>match</key>
+					<string>\b(?:while|repeat|for|in)\b</string>
+					<key>name</key>
+					<string>keyword.control.loop.swift</string>
 				</dict>
 				<dict>
-					<key>include</key>
-					<string>#declaration-specifier</string>
+					<key>match</key>
+					<string>\bdefer\b</string>
+					<key>name</key>
+					<string>keyword.control.defer.swift</string>
 				</dict>
 				<dict>
-					<key>include</key>
-					<string>#capture-specifier</string>
+					<key>match</key>
+					<string>\b(?:do|catch|throws?|rethrows|try)\b|try[?!]\B</string>
+					<key>name</key>
+					<string>keyword.control.exception.swift</string>
 				</dict>
 				<dict>
-					<key>include</key>
-					<string>#operator-declaration-keyword</string>
+					<key>match</key>
+					<string>\b(?:associatedtype|let|operator|typealias|var)\b</string>
+					<key>name</key>
+					<string>keyword.other.declaration-specifier.swift</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(?:class|enum|extension|protocol|struct)\b</string>
+					<key>name</key>
+					<string>storage.type.class.swift</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(?:inout|static|final|lazy|mutating|nonmutating|optional|indirect|required|override|dynamic|convenience)\b</string>
+					<key>name</key>
+					<string>storage.modifier.swift</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(?:func|init|deinit|subscript|didSet|get|set|willSet)\b</string>
+					<key>name</key>
+					<string>storage.type.function.swift</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(?:fileprivate|internal|private|public)\b</string>
+					<key>name</key>
+					<string>keyword.other.declaration-specifier.accessibility.swift</string>
 				</dict>
 				<dict>
 					<key>comment</key>
-					<string>declaration keyword</string>
+					<string>matches weak, unowned, unowned(safe), unowned(unsafe)</string>
 					<key>match</key>
-					<string>\b(class|deinit|enum|extension|func|import|init|inout|internal|let|operator|private|protocol|public|static|struct|subscript|typealias|var)\b</string>
+					<string>\b(?:weak\b|unowned(?:\((?:un)?safe\))?)</string>
 					<key>name</key>
-					<string>storage.type.declaration.swift</string>
+					<string>keyword.other.capture-specifier.swift</string>
 				</dict>
 				<dict>
-					<key>comment</key>
-					<string>statement keyword</string>
 					<key>match</key>
-					<string>\b(break|case|continue|default|defer|do|else|fallthrough|for|guard|if|in|repeat|return|switch|where|while)\b</string>
+					<string>\b(?:operator|prefix|infix|postfix|precedencegroup|higherThan|lowerThan|left|associativity|right|precedence)\b</string>
 					<key>name</key>
-					<string>keyword.control.statement.swift</string>
+					<string>keyword.other.operator.swift</string>
 				</dict>
 				<dict>
-					<key>comment</key>
-					<string>expression and type keyword</string>
 					<key>match</key>
-					<string>\b(as|catch|dynamicType|false|is|nil|rethrows|super|self|Self|throw|throws|true|try|__COLUMN__|__FILE__|__FUNCTION__|__LINE__)\b</string>
+					<string>\b(?:super|self)\b</string>
 					<key>name</key>
-					<string>keyword.other.statement.swift</string>
+					<string>variable.language.swift</string>
 				</dict>
 				<dict>
-					<key>comment</key>
-					<string>other keyword</string>
 					<key>match</key>
-					<string>\b(associativity|convenience|dynamic|didSet|final|get|infix|indirect|lazy|left|mutating|none|nonmutating|optional|override|postfix|precedence|prefix|Protocol|required|right|set|Type|unowned|weak|willSet)\b</string>
+					<string>\B(?:#file|#line|#column|#function|#dsohandle)\b|\b(?:__FILE__|__LINE__|__COLUMN__|__FUNCTION__|__DSO_HANDLE__)\b</string>
 					<key>name</key>
-					<string>keyword.other.swift</string>
+					<string>support.variable.swift</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(?:dynamicType|Protocol|Type)\b</string>
+					<key>name</key>
+					<string>keyword.operator.other.swift</string>
 				</dict>
 			</array>
 		</dict>
@@ -1035,15 +929,19 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#special-literal</string>
-				</dict>
-				<dict>
-					<key>include</key>
 					<string>#boolean-literal</string>
 				</dict>
 				<dict>
 					<key>include</key>
 					<string>#nil-literal</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>object "literals" used in playgrounds</string>
+					<key>match</key>
+					<string>\B(?:#colorLiteral|#imageLiteral|#fileLiteral)\b</string>
+					<key>name</key>
+					<string>support.function.object-literal.swift</string>
 				</dict>
 			</array>
 		</dict>
@@ -1053,15 +951,6 @@
 			<string>(?&lt;![/=\-+!*%&lt;&gt;&amp;|\^~.])(!|&amp;&amp;|\|\|)(?![/=\-+!*%&lt;&gt;&amp;|\^~.])</string>
 			<key>name</key>
 			<string>keyword.operator.logical.swift</string>
-		</dict>
-		<key>loop-statement-keyword</key>
-		<dict>
-			<key>comment</key>
-			<string>loop-statement</string>
-			<key>match</key>
-			<string>\b(while|do|for|in)\b</string>
-			<key>name</key>
-			<string>keyword.control.loop.swift</string>
 		</dict>
 		<key>nil-literal</key>
 		<dict>
@@ -1127,15 +1016,6 @@
 					<string>#custom-operator</string>
 				</dict>
 			</array>
-		</dict>
-		<key>operator-declaration-keyword</key>
-		<dict>
-			<key>comment</key>
-			<string>operator-declaration</string>
-			<key>match</key>
-			<string>\b(operator|prefix|infix|postfix)\b</string>
-			<key>name</key>
-			<string>keyword.other.operator.swift</string>
 		</dict>
 		<key>optional-type</key>
 		<dict>
@@ -1365,13 +1245,6 @@
 			<key>name</key>
 			<string>comment.line.shebang.swift</string>
 		</dict>
-		<key>special-literal</key>
-		<dict>
-			<key>match</key>
-			<string>\b__(FILE|LINE|COLUMN|FUNCTION)__\b</string>
-			<key>name</key>
-			<string>keyword.other.literal.swift</string>
-		</dict>
 		<key>storage-type</key>
 		<dict>
 			<key>match</key>
@@ -1495,15 +1368,6 @@
 				</dict>
 			</array>
 		</dict>
-		<key>switch-statement-keyword</key>
-		<dict>
-			<key>comment</key>
-			<string>switch-statement</string>
-			<key>match</key>
-			<string>\b(switch|case|default|where)\b</string>
-			<key>name</key>
-			<string>keyword.control.switch.swift</string>
-		</dict>
 		<key>ternary-operator</key>
 		<dict>
 			<key>match</key>
@@ -1523,15 +1387,17 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#collection-type</string>
-				</dict>
-				<dict>
-					<key>include</key>
 					<string>#optional-type</string>
 				</dict>
 				<dict>
 					<key>include</key>
 					<string>#protocol-composition-type</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\bSelf\b</string>
+					<key>name</key>
+					<string>variable.language.swift</string>
 				</dict>
 			</array>
 		</dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -1708,9 +1708,9 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(?:class|enum|extension|protocol|struct)\b</string>
+					<string>\b(class|enum|extension|precedencegroup|protocol|struct)\b</string>
 					<key>name</key>
-					<string>storage.type.class.swift</string>
+					<string>storage.type.$1.swift</string>
 				</dict>
 				<dict>
 					<key>match</key>
@@ -1755,6 +1755,12 @@
 					<string>\b(?:dynamicType|Protocol|Type)\b</string>
 					<key>name</key>
 					<string>keyword.operator.other.swift</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\bimport\b</string>
+					<key>name</key>
+					<string>keyword.control.import.swift</string>
 				</dict>
 			</array>
 		</dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -1237,6 +1237,35 @@
 				</dict>
 			</array>
 		</dict>
+		<key>declaration-typealias</key>
+		<dict>
+			<key>begin</key>
+			<string>\b(typealias)\s+((?!\d)\w[\w\d]*\b|\B`(?!\d)\w[\w\d]*`\B)\s*(?=[&lt;=])</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.other.declaration-specifier.swift</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.type.typealias.swift</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?!\G)</string>
+			<key>name</key>
+			<string>meta.definition.typealias.swift</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#generic-parameter-list</string>
+				</dict>
+			</array>
+		</dict>
 		<key>function-result</key>
 		<dict>
 			<key>begin</key>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -409,7 +409,7 @@
 				<key>block-doc</key>
 				<dict>
 					<key>begin</key>
-					<string>/\*\*</string>
+					<string>/\*\*(?!\/)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>0</key>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -40,11 +40,11 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#operator</string>
+			<string>#declaration</string>
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#declaration</string>
+			<string>#operator</string>
 		</dict>
 		<dict>
 			<key>include</key>
@@ -103,7 +103,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>((@)(\b[\w^\d][\w\d]*\b|\B`[\w^\d][\w\d]*`\B))(\()</string>
+					<string>((@)(\b(?!\d)\w[\w\d]*\b|\B`(?!\d)\w[\w\d]*`\B))(\()</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -157,7 +157,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>((@)(\b[\w^\d][\w\d]*\b|\B`[\w^\d][\w\d]*`\B))</string>
+					<string>((@)(\b(?!\d)\w[\w\d]*\b|\B`(?!\d)\w[\w\d]*`\B))</string>
 				</dict>
 			</array>
 		</dict>
@@ -658,34 +658,44 @@
 		</dict>
 		<key>declaration</key>
 		<dict>
-			<key>comment</key>
-			<string>declaration</string>
 			<key>name</key>
-			<string>meta.declaration.swift</string>
+			<string>meta.definition.swift</string>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#import-declaration</string>
+					<string>#declaration-import</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#function-declaration</string>
+					<string>#declaration-function</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#operator-declaration</string>
+					<string>#declaration-function-initializer</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#precedence-group-declaration</string>
+					<string>#declaration-operator</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#declaration-type</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#declaration-typealias</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#declaration-precedencegroup</string>
 				</dict>
 			</array>
 		</dict>
-		<key>function-declaration</key>
+		<key>declaration-function</key>
 		<dict>
 			<key>begin</key>
-			<string>\b(func)\s+(\b[\w^\d][\w\d]*\b|\B`[\w^\d][\w\d]*`\B|[/=\-+!*%&lt;&gt;&amp;|\^~.]+)\s*(?=\(|&lt;)</string>
+			<string>\b(func)\s+(\b(?!\d)\w[\w\d]*\b|\B`(?!\d)\w[\w\d]*`\B|[/=\-+!*%&lt;&gt;&amp;|\^~.]+)\s*(?=\(|&lt;)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -699,17 +709,19 @@
 					<string>entity.name.function.swift</string>
 				</dict>
 			</dict>
-			<key>comment</key>
-			<string>function-declaration</string>
 			<key>end</key>
-			<string>(?&lt;=\})|$</string>
+			<string>(?&lt;=\})|$(?# functions in protocol declarations or generated interfaces have no body)</string>
 			<key>name</key>
-			<string>meta.function-declaration.swift</string>
+			<string>meta.definition.function.swift</string>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#generic-parameter-clause</string>
+					<string>#comment</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#generic-parameter-list</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -718,6 +730,18 @@
 				<dict>
 					<key>include</key>
 					<string>#function-result</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(?:throws|rethrows)\b</string>
+					<key>name</key>
+					<string>keyword.control.exception.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Swift 3: generic constraints after the parameters and return type</string>
+					<key>include</key>
+					<string>#generic-constraints</string>
 				</dict>
 				<dict>
 					<key>begin</key>
@@ -741,78 +765,101 @@
 						</dict>
 					</dict>
 					<key>name</key>
-					<string>meta.function-declaration.body.swift</string>
+					<string>meta.definition.function.body.swift</string>
 					<key>patterns</key>
 					<array>
 						<dict>
 							<key>include</key>
 							<string>$self</string>
 						</dict>
+						<dict>
+							<key>include</key>
+							<string>#nested-braces</string>
+						</dict>
 					</array>
 				</dict>
 			</array>
 		</dict>
-		<key>function-result</key>
+		<key>declaration-function-initializer</key>
 		<dict>
 			<key>begin</key>
-			<string>(?&lt;![/=\-+!*%&lt;&gt;&amp;|\^~.])(\-&gt;)(?![/=\-+!*%&lt;&gt;&amp;|\^~.])\s*</string>
+			<string>\b(init[?!]?)\s*(?=\(|&lt;)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.operator.function-result.swift</string>
+					<string>storage.type.function.swift</string>
 				</dict>
 			</dict>
-			<key>comment</key>
-			<string>function-result</string>
 			<key>end</key>
-			<string>(?=\{)|$</string>
+			<string>(?&lt;=\})|$</string>
 			<key>name</key>
-			<string>meta.function-result.swift</string>
+			<string>meta.definition.function.initializer.swift</string>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#type</string>
+					<string>#comment</string>
 				</dict>
-			</array>
-		</dict>
-		<key>generic-parameter-clause</key>
-		<dict>
-			<key>begin</key>
-			<string>(&lt;)</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.generic-parameter-clause.begin.swift</string>
-				</dict>
-			</dict>
-			<key>comment</key>
-			<string>generic-parameter-clause</string>
-			<key>end</key>
-			<string>(&gt;)</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.generic-parameter-clause.end.swift</string>
-				</dict>
-			</dict>
-			<key>name</key>
-			<string>meta.generic-parameter-clause.swift</string>
-			<key>patterns</key>
-			<array>
 				<dict>
 					<key>include</key>
-					<string>$self</string>
+					<string>#generic-parameter-list</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#parameter-clause</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(?:throws|rethrows)\b</string>
+					<key>name</key>
+					<string>keyword.control.exception.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Swift 3: generic constraints after the parameters and return type</string>
+					<key>include</key>
+					<string>#generic-constraints</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(\{)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.begin.swift</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(\})</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.function.end.swift</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.definition.function.initializer.body.swift</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>$self</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#nested-braces</string>
+						</dict>
+					</array>
 				</dict>
 			</array>
 		</dict>
-		<key>import-declaration</key>
+		<key>declaration-import</key>
 		<dict>
 			<key>captures</key>
 			<dict>
@@ -832,12 +879,441 @@
 					<string>support.type.module.import.swift</string>
 				</dict>
 			</dict>
-			<key>comment</key>
-			<string>import-declaration</string>
 			<key>match</key>
-			<string>\b(import)\s+(?:(typealias|struct|class|enum|protocol|var|func)\s+)?((?:\B\$[0-9]+|\b[\w^\d][\w\d]*\b|\B`[\w^\d][\w\d]*`\B|[/=\-+!*%&lt;&gt;&amp;|\^~.]+)(?:\.(?:\B\$[0-9]+|\b[\w^\d][\w\d]*\b|\B`[\w^\d][\w\d]*`\B|[/=\-+!*%&lt;&gt;&amp;|\^~.]+))*)</string>
+			<string>\b(import)\s+(?:(typealias|struct|class|enum|protocol|var|func)\s+)?((?:\B\$[0-9]+|\b(?!\d)\w[\w\d]*\b|\B`(?!\d)\w[\w\d]*`\B|[/=\-+!*%&lt;&gt;&amp;|\^~.]+)(?:\.(?:\B\$[0-9]+|\b(?!\d)\w[\w\d]*\b|\B`(?!\d)\w[\w\d]*`\B|[/=\-+!*%&lt;&gt;&amp;|\^~.]+))*)</string>
 			<key>name</key>
 			<string>meta.import.swift</string>
+		</dict>
+		<key>declaration-operator</key>
+		<dict>
+			<key>begin</key>
+			<string>\b(prefix|infix|postfix)?\s+(operator)\s+([/=\-+!*%&lt;&gt;&amp;|\^~.]+)\s*(?=[:{])</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.modifier.swift</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.function.operator.swift</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.custom.swift</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?!\G)</string>
+			<key>name</key>
+			<string>meta.definition.operator.swift</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#declaration-operator-swift2</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#declaration-operator-swift3</string>
+				</dict>
+			</array>
+		</dict>
+		<key>declaration-operator-swift2</key>
+		<dict>
+			<key>begin</key>
+			<string>(\{)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.operator.begin.swift</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(\})</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.operator.end.swift</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>storage.modifier.swift</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.operator.associativity.swift</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>\b(associativity)\s+(left|right)\b</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>storage.modifier.swift</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>constant.numeric.integer.swift</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>\b(precedence)\s+([0-9]+)\b</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>storage.modifier.swift</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>\b(assignment)\b</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comment</string>
+				</dict>
+			</array>
+		</dict>
+		<key>declaration-operator-swift3</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.other.inherited-class.swift</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(:)\s*((?!\d)\w[\w\d]*\b|\B`(?!\d)\w[\w\d]*`\B)</string>
+		</dict>
+		<key>declaration-precedencegroup</key>
+		<dict>
+			<key>begin</key>
+			<string>\b(precedencegroup)\s+((?!\d)\w[\w\d]*\b|\B`(?!\d)\w[\w\d]*`\B)\s*(?=\{)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.precedencegroup.swift</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.type.precedencegroup.swift</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?!\G)</string>
+			<key>name</key>
+			<string>meta.definition.precedencegroup.swift</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>(\{)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.precedencegroup.begin.swift</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(\})</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.precedencegroup.end.swift</string>
+						</dict>
+					</dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>storage.modifier.swift</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>entity.other.inherited-class.swift</string>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>\b(higherThan|lowerThan)\s*:\s*((?!\d)\w[\w\d]*\b|\B`(?!\d)\w[\w\d]*`\B)</string>
+						</dict>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>storage.modifier.swift</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>keyword.other.operator.associativity.swift</string>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>\b(associativity)\b(?:\s*:\s*(right|left)\b)?</string>
+						</dict>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>storage.modifier.swift</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>constant.language.boolean.swift</string>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>\b(assignment)\b(?:\s*:\s*(true|false)\b)?</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<key>declaration-type</key>
+		<dict>
+			<key>begin</key>
+			<string>\b(?:(class)|(struct)|(enum))\s+((?!\d)\w[\w\d]*\b|\B`(?!\d)\w[\w\d]*`\B)\s*(?=\{|&lt;)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.class.swift</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.struct.swift</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.enum.swift</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.type.swift</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?&lt;=\})|$</string>
+			<key>name</key>
+			<string>meta.definition.type.swift</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#comment</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#generic-parameter-list</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Swift 3: generic constraints after the generic param list</string>
+					<key>include</key>
+					<string>#generic-constraints</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(\{)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.type.begin.swift</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(\})</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.type.end.swift</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.definition.type.body.swift</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>$self</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#nested-braces</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<key>function-result</key>
+		<dict>
+			<key>begin</key>
+			<string>(?&lt;![/=\-+!*%&lt;&gt;&amp;|\^~.])(-&gt;)(?![/=\-+!*%&lt;&gt;&amp;|\^~.])\s*</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.type.function.swift</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?!\G)(?=\{|\bwhere\b)|$</string>
+			<key>name</key>
+			<string>meta.function-result.swift</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#type</string>
+				</dict>
+			</array>
+		</dict>
+		<key>generic-constraints</key>
+		<dict>
+			<key>begin</key>
+			<string>\b(where)\b</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.other.generic-constraint-introducer.swift</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?=\s*\{|&gt;)</string>
+			<key>name</key>
+			<string>meta.generic-constraints.swift</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#comment</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#type</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.generic-constraint.same-type.swift</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.generic-constraint.conforms-to.swift</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?&lt;![/=\-+!*%&lt;&gt;&amp;|\^~.])(?:(==)|(:))(?![/=\-+!*%&lt;&gt;&amp;|\^~.])</string>
+				</dict>
+			</array>
+		</dict>
+		<key>generic-parameter-list</key>
+		<dict>
+			<key>begin</key>
+			<string>(&lt;)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.generic-parameter-list.begin.swift</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(&gt;)|(?=[^\w\d&lt;&gt;\s,=&amp;`])(?# characters besides these are never valid in a generic param list -- even if it's not really a valid clause, we should stop trying to parse it if we see one of them.)</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.generic-parameter-list.end.swift</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>meta.generic-parameter-list.swift</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#comment</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Swift 2: constraints inside the generic param list</string>
+					<key>include</key>
+					<string>#generic-constraints</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>variable.language.generic-parameter.swift</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>\b((?!\d)\w[\w\d]*)\b</string>
+				</dict>
+			</array>
 		</dict>
 		<key>increment-decrement-operator</key>
 		<dict>
@@ -900,7 +1376,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(?:func|init|deinit|subscript|didSet|get|set|willSet)\b</string>
+					<string>\binit[?!]|\b(?:func|init|deinit|subscript|didSet|get|set|willSet)\b</string>
 					<key>name</key>
 					<string>storage.type.function.swift</string>
 				</dict>
@@ -978,6 +1454,40 @@
 			<string>(?&lt;![/=\-+!*%&lt;&gt;&amp;|\^~.])(!|&amp;&amp;|\|\|)(?![/=\-+!*%&lt;&gt;&amp;|\^~.])</string>
 			<key>name</key>
 			<string>keyword.operator.logical.swift</string>
+		</dict>
+		<key>nested-braces</key>
+		<dict>
+			<key>begin</key>
+			<string>(\{)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.scope.begin.swift</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(\})</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.scope.end.swift</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#nested-braces</string>
+				</dict>
+			</array>
 		</dict>
 		<key>numeric-literal</key>
 		<dict>
@@ -1135,133 +1645,6 @@
 				</dict>
 			</array>
 		</dict>
-		<key>operator-declaration</key>
-		<dict>
-			<key>begin</key>
-			<string>\b(prefix|infix|postfix)?\s+(operator)\s+([/=\-+!*%&lt;&gt;&amp;|\^~.]+)\s*(?=[:{])</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>storage.modifier.swift</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>storage.type.function.operator.swift</string>
-				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.operator.custom.swift</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>(?!\G)</string>
-			<key>name</key>
-			<string>meta.definition.operator.swift</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#operator-declaration-swift2</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#operator-declaration-swift3</string>
-				</dict>
-			</array>
-		</dict>
-		<key>operator-declaration-swift2</key>
-		<dict>
-			<key>begin</key>
-			<string>(\{)</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.operator.begin.swift</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>(\})</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.operator.end.swift</string>
-				</dict>
-			</dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>storage.modifier.swift</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.other.operator.associativity.swift</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>\b(associativity)\s+(left|right)\b</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>storage.modifier.swift</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>constant.numeric.integer.swift</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>\b(precedence)\s+([0-9]+)\b</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>storage.modifier.swift</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>\b(assignment)\b</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#comment</string>
-				</dict>
-			</array>
-		</dict>
-		<key>operator-declaration-swift3</key>
-		<dict>
-			<key>captures</key>
-			<dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>entity.other.inherited-class.swift</string>
-				</dict>
-			</dict>
-			<key>match</key>
-			<string>(:)\s*([\w^\d][\w\d]*\b|\B`[\w^\d][\w\d]*`\B)</string>
-		</dict>
 		<key>overflow-operator</key>
 		<dict>
 			<key>match</key>
@@ -1281,8 +1664,6 @@
 					<string>punctuation.definition.function-arguments.begin.swift</string>
 				</dict>
 			</dict>
-			<key>comment</key>
-			<string>parameter-clause</string>
 			<key>end</key>
 			<string>(\))</string>
 			<key>endCaptures</key>
@@ -1312,114 +1693,32 @@
 						</dict>
 					</dict>
 					<key>comment</key>
-					<string>named parameters</string>
+					<string>External parameter labels are considered part of the function name</string>
 					<key>match</key>
-					<string>\b([\w^\d][\w\d]*)\b\s+\b([\w^\d][\w\d]*)\b</string>
+					<string>\b((?!\d)\w[\w\d]*)\b\s+\b((?!\d)\w[\w\d]*)\b(?=\s*:)</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.function.swift</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>variable.parameter.function.swift</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>If no external label is given, the name is both the external label and the internal variable name</string>
+					<key>match</key>
+					<string>\b(((?!\d)\w[\w\d]*))\b(?=\s*:)</string>
 				</dict>
 				<dict>
 					<key>include</key>
 					<string>$self</string>
-				</dict>
-			</array>
-		</dict>
-		<key>precedence-group-declaration</key>
-		<dict>
-			<key>begin</key>
-			<string>\b(precedencegroup)\s+([\w^\d][\w\d]*\b|\B`[\w^\d][\w\d]*`\B)\s*(?=\{)</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>storage.type.precedencegroup.swift</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>entity.name.type.precedencegroup.swift</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>(?!\G)</string>
-			<key>name</key>
-			<string>meta.definition.precedencegroup.swift</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>begin</key>
-					<string>(\{)</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.precedencegroup.begin.swift</string>
-						</dict>
-					</dict>
-					<key>end</key>
-					<string>(\})</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.precedencegroup.end.swift</string>
-						</dict>
-					</dict>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>captures</key>
-							<dict>
-								<key>1</key>
-								<dict>
-									<key>name</key>
-									<string>storage.modifier.swift</string>
-								</dict>
-								<key>2</key>
-								<dict>
-									<key>name</key>
-									<string>entity.other.inherited-class.swift</string>
-								</dict>
-							</dict>
-							<key>match</key>
-							<string>\b(higherThan|lowerThan)\s*:\s*([\w^\d][\w\d]*\b|\B`[\w^\d][\w\d]*`\B)</string>
-						</dict>
-						<dict>
-							<key>captures</key>
-							<dict>
-								<key>1</key>
-								<dict>
-									<key>name</key>
-									<string>storage.modifier.swift</string>
-								</dict>
-								<key>2</key>
-								<dict>
-									<key>name</key>
-									<string>keyword.other.operator.associativity.swift</string>
-								</dict>
-							</dict>
-							<key>match</key>
-							<string>\b(associativity)\b(?:\s*:\s*(right|left)\b)?</string>
-						</dict>
-						<dict>
-							<key>captures</key>
-							<dict>
-								<key>1</key>
-								<dict>
-									<key>name</key>
-									<string>storage.modifier.swift</string>
-								</dict>
-								<key>2</key>
-								<dict>
-									<key>name</key>
-									<string>constant.language.boolean.swift</string>
-								</dict>
-							</dict>
-							<key>match</key>
-							<string>\b(assignment)\b(?:\s*:\s*(true|false)\b)?</string>
-						</dict>
-					</array>
 				</dict>
 			</array>
 		</dict>
@@ -1642,8 +1941,6 @@
 		</dict>
 		<key>type</key>
 		<dict>
-			<key>comment</key>
-			<string>type</string>
 			<key>patterns</key>
 			<array>
 				<dict>
@@ -1651,10 +1948,66 @@
 					<string>#builtin-type</string>
 				</dict>
 				<dict>
+					<key>include</key>
+					<string>#attribute</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\b(?:throws|rethrows)\b</string>
+					<key>name</key>
+					<string>keyword.control.exception.swift</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\binout\b</string>
+					<key>name</key>
+					<string>storage.modifier.swift</string>
+				</dict>
+				<dict>
 					<key>match</key>
 					<string>\bSelf\b</string>
 					<key>name</key>
 					<string>variable.language.swift</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.type.function.swift</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?&lt;![/=\-+!*%&lt;&gt;&amp;|\^~.])(-&gt;)(?![/=\-+!*%&lt;&gt;&amp;|\^~.])</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.type.composition.swift</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Swift 3: A &amp; B</string>
+					<key>match</key>
+					<string>(?&lt;![/=\-+!*%&lt;&gt;&amp;|\^~.])(&amp;)(?![/=\-+!*%&lt;&gt;&amp;|\^~.])</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\bAny\b</string>
+					<key>name</key>
+					<string>keyword.operator.type.any.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Swift 2: protocol&lt;A, B&gt;</string>
+					<key>match</key>
+					<string>\bprotocol\b</string>
+					<key>name</key>
+					<string>keyword.operator.type.composition.swift</string>
 				</dict>
 			</array>
 		</dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -20,6 +20,10 @@
 		</dict>
 		<dict>
 			<key>include</key>
+			<string>#conditional-compilation</string>
+		</dict>
+		<dict>
+			<key>include</key>
 			<string>#comment</string>
 		</dict>
 		<dict>
@@ -535,6 +539,98 @@
 			<string>(?&lt;![/=\-+!*%&lt;&gt;&amp;|\^~.])((=|!)==?|(&lt;|&gt;)=?|~=)(?![/=\-+!*%&lt;&gt;&amp;|\^~.])</string>
 			<key>name</key>
 			<string>keyword.operator.comparison.swift</string>
+		</dict>
+		<key>conditional-compilation</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>^\s*(?:#if|#elseif)\s+</string>
+					<key>end</key>
+					<string>(?=\s*(?://|/\*))|$</string>
+					<key>name</key>
+					<string>meta.preprocessor.conditional.swift</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#logical-operator</string>
+						</dict>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>keyword.control.import.swift</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>support.constant.platform.architecture.swift</string>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>\b(arch)\s*\(\s*(?:(arm|arm64|powerpc64|powerpc64le|i386|x86_64|s390x)|\w+)\s*\)</string>
+						</dict>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>keyword.control.import.swift</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>support.constant.platform.os.swift</string>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>\b(os)\s*\(\s*(?:(macOS|OSX|iOS|tvOS|watchOS|Android|Linux|FreeBSD|Windows|PS4)|\w+)\s*\)</string>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>\b(swift)\s*\(</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>keyword.control.import.swift</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>\)|$</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>match</key>
+									<string>&gt;=</string>
+									<key>name</key>
+									<string>keyword.operator.comparison.swift</string>
+								</dict>
+								<dict>
+									<key>match</key>
+									<string>\b[0-9]+(?:\.[0-9]+)*\b</string>
+									<key>name</key>
+									<string>constant.numeric.swift</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>^\s*#endif\s+</string>
+					<key>end</key>
+					<string>(?=\s*(?://|/\*))|$</string>
+					<key>name</key>
+					<string>meta.preprocessor.swift</string>
+				</dict>
+			</array>
 		</dict>
 		<key>custom-operator</key>
 		<dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -280,6 +280,20 @@
 				</dict>
 			</array>
 		</dict>
+		<key>builtin-precedencegroup</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>comment</key>
+					<string>Precedence groups in the standard library</string>
+					<key>match</key>
+					<string>\b(?:BitwiseShift|Assignment|RangeFormation|Casting|Addition|NilCoalescing|Comparison|LogicalConjunction|LogicalDisjunction|Default|Ternary|Multiplication|FunctionArrow)Precedence\b</string>
+					<key>name</key>
+					<string>support.type.swift</string>
+				</dict>
+			</array>
+		</dict>
 		<key>builtin-property</key>
 		<dict>
 			<key>patterns</key>
@@ -1156,6 +1170,13 @@
 				<dict>
 					<key>name</key>
 					<string>entity.other.inherited-class.swift</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#builtin-precedencegroup</string>
+						</dict>
+					</array>
 				</dict>
 			</dict>
 			<key>match</key>
@@ -1219,6 +1240,13 @@
 								<dict>
 									<key>name</key>
 									<string>entity.other.inherited-class.swift</string>
+									<key>patterns</key>
+									<array>
+										<dict>
+											<key>include</key>
+											<string>#builtin-precedencegroup</string>
+										</dict>
+									</array>
 								</dict>
 							</dict>
 							<key>match</key>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -168,6 +168,13 @@
 			<key>name</key>
 			<string>keyword.operator.bitwise.swift</string>
 		</dict>
+		<key>boolean-literal</key>
+		<dict>
+			<key>match</key>
+			<string>\b(true|false)\b</string>
+			<key>name</key>
+			<string>constant.language.boolean.swift</string>
+		</dict>
 		<key>builtin-class-type</key>
 		<dict>
 			<key>comment</key>
@@ -546,6 +553,36 @@
 			<array>
 				<dict>
 					<key>begin</key>
+					<string>^\s*(#if|#elseif)\s+(false)\b.*$</string>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>meta.preprocessor.swift</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>constant.language.boolean.swift</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>^\s*(#endif)\b</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>begin</key>
+							<string></string>
+							<key>end</key>
+							<string>(?=^\s*#endif\b)</string>
+							<key>name</key>
+							<string>comment.block.preprocessor.swift</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>begin</key>
 					<string>^\s*(?:#if|#elseif)\s+</string>
 					<key>end</key>
 					<string>(?=\s*(?://|/\*))|$</string>
@@ -556,6 +593,10 @@
 						<dict>
 							<key>include</key>
 							<string>#logical-operator</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#boolean-literal</string>
 						</dict>
 						<dict>
 							<key>captures</key>
@@ -1427,10 +1468,8 @@
 					<string>#string-literal</string>
 				</dict>
 				<dict>
-					<key>match</key>
-					<string>\b(true|false)\b</string>
-					<key>name</key>
-					<string>constant.language.boolean.swift</string>
+					<key>include</key>
+					<string>#boolean-literal</string>
 				</dict>
 				<dict>
 					<key>match</key>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -160,13 +160,6 @@
 			<key>name</key>
 			<string>keyword.operator.bitwise.swift</string>
 		</dict>
-		<key>boolean-literal</key>
-		<dict>
-			<key>match</key>
-			<string>\b(true|false)\b</string>
-			<key>name</key>
-			<string>constant.language.boolean.swift</string>
-		</dict>
 		<key>builtin-class-type</key>
 		<dict>
 			<key>comment</key>
@@ -719,7 +712,7 @@
 						</dict>
 						<dict>
 							<key>include</key>
-							<string>#boolean-literal</string>
+							<string>#literal-boolean</string>
 						</dict>
 						<dict>
 							<key>captures</key>
@@ -1771,15 +1764,15 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#numeric-literal</string>
+					<string>#literal-numeric</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#string-literal</string>
+					<string>#literal-string</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#boolean-literal</string>
+					<string>#literal-boolean</string>
 				</dict>
 				<dict>
 					<key>match</key>
@@ -1797,48 +1790,14 @@
 				</dict>
 			</array>
 		</dict>
-		<key>logical-operator</key>
+		<key>literal-boolean</key>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;![/=\-+!*%&lt;&gt;&amp;|\^~.])(!|&amp;&amp;|\|\|)(?![/=\-+!*%&lt;&gt;&amp;|\^~.])</string>
+			<string>\b(true|false)\b</string>
 			<key>name</key>
-			<string>keyword.operator.logical.swift</string>
+			<string>constant.language.boolean.swift</string>
 		</dict>
-		<key>nested-braces</key>
-		<dict>
-			<key>begin</key>
-			<string>(\{)</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.section.scope.begin.swift</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>(\})</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.section.scope.end.swift</string>
-				</dict>
-			</dict>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>$self</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#nested-braces</string>
-				</dict>
-			</array>
-		</dict>
-		<key>numeric-literal</key>
+		<key>literal-numeric</key>
 		<dict>
 			<key>patterns</key>
 			<array>
@@ -1933,6 +1892,163 @@
 					<string>(\B\-|\b)[0-9][\w.]*</string>
 					<key>name</key>
 					<string>invalid.illegal.numeric.other.swift</string>
+				</dict>
+			</array>
+		</dict>
+		<key>literal-string</key>
+		<dict>
+			<key>begin</key>
+			<string>"</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.begin.swift</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>"</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.end.swift</string>
+				</dict>
+			</dict>
+			<key>name</key>
+			<string>string.quoted.double.swift</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.escape.swift</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(\\)[0\\tnr"']</string>
+					<key>name</key>
+					<string>constant.character.escape.swift</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.escape.swift</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(\\)u\{\h{1,8}\}</string>
+					<key>name</key>
+					<string>constant.character.escape.swift</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>\\\(</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.embedded.begin.swift</string>
+						</dict>
+					</dict>
+					<key>contentName</key>
+					<string>source.swift</string>
+					<key>end</key>
+					<string>\)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.embedded.end.swift</string>
+						</dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>source.swift</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.embedded.line.swift</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>$self</string>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>\(</string>
+							<key>comment</key>
+							<string>Nested parens</string>
+							<key>end</key>
+							<string>\)</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.escape.swift</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(\\).</string>
+					<key>name</key>
+					<string>invalid.illegal.unrecognized-escape.swift</string>
+				</dict>
+			</array>
+		</dict>
+		<key>logical-operator</key>
+		<dict>
+			<key>match</key>
+			<string>(?&lt;![/=\-+!*%&lt;&gt;&amp;|\^~.])(!|&amp;&amp;|\|\|)(?![/=\-+!*%&lt;&gt;&amp;|\^~.])</string>
+			<key>name</key>
+			<string>keyword.operator.logical.swift</string>
+		</dict>
+		<key>nested-braces</key>
+		<dict>
+			<key>begin</key>
+			<string>(\{)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.scope.begin.swift</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(\})</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.scope.end.swift</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#nested-braces</string>
 				</dict>
 			</array>
 		</dict>
@@ -2164,122 +2280,6 @@
 			<string>^(#!).*$</string>
 			<key>name</key>
 			<string>comment.line.shebang.swift</string>
-		</dict>
-		<key>string-literal</key>
-		<dict>
-			<key>begin</key>
-			<string>"</string>
-			<key>beginCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.string.begin.swift</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>"</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.string.end.swift</string>
-				</dict>
-			</dict>
-			<key>name</key>
-			<string>string.quoted.double.swift</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.escape.swift</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(\\)[0\\tnr"']</string>
-					<key>name</key>
-					<string>constant.character.escape.swift</string>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.escape.swift</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(\\)u\{\h{1,8}\}</string>
-					<key>name</key>
-					<string>constant.character.escape.swift</string>
-				</dict>
-				<dict>
-					<key>begin</key>
-					<string>\\\(</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.embedded.begin.swift</string>
-						</dict>
-					</dict>
-					<key>contentName</key>
-					<string>source.swift</string>
-					<key>end</key>
-					<string>\)</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.section.embedded.end.swift</string>
-						</dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>source.swift</string>
-						</dict>
-					</dict>
-					<key>name</key>
-					<string>meta.embedded.line.swift</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>$self</string>
-						</dict>
-						<dict>
-							<key>begin</key>
-							<string>\(</string>
-							<key>comment</key>
-							<string>Nested parens</string>
-							<key>end</key>
-							<string>\)</string>
-						</dict>
-					</array>
-				</dict>
-				<dict>
-					<key>captures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.escape.swift</string>
-						</dict>
-					</dict>
-					<key>match</key>
-					<string>(\\).</string>
-					<key>name</key>
-					<string>invalid.illegal.unrecognized-escape.swift</string>
-				</dict>
-			</array>
 		</dict>
 		<key>ternary-operator</key>
 		<dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -28,6 +28,10 @@
 		</dict>
 		<dict>
 			<key>include</key>
+			<string>#closure-parameter</string>
+		</dict>
+		<dict>
+			<key>include</key>
 			<string>#literal</string>
 		</dict>
 		<dict>
@@ -37,10 +41,6 @@
 		<dict>
 			<key>include</key>
 			<string>#declaration</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#storage-type</string>
 		</dict>
 		<dict>
 			<key>include</key>
@@ -93,15 +93,13 @@
 		</dict>
 		<key>attribute</key>
 		<dict>
-			<key>comment</key>
-			<string>attribute</string>
 			<key>name</key>
 			<string>meta.attribute.swift</string>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>((@)(\B\$[0-9]+|\b[\w^\d][\w\d]*\b|\B`[\w^\d][\w\d]*`\B))(\()</string>
+					<string>((@)(\b[\w^\d][\w\d]*\b|\B`[\w^\d][\w\d]*`\B))(\()</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -155,7 +153,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>((@)(\B\$[0-9]+|\b[\w^\d][\w\d]*\b|\B`[\w^\d][\w\d]*`\B))</string>
+					<string>((@)(\b[\w^\d][\w\d]*\b|\B`[\w^\d][\w\d]*`\B))</string>
 				</dict>
 			</array>
 		</dict>
@@ -165,13 +163,6 @@
 			<string>(?&lt;![/=\-+!*%&lt;&gt;&amp;|\^~.])(&amp;|\||\^|&lt;&lt;|&gt;&gt;)(?![/=\-+!*%&lt;&gt;&amp;|\^~.])</string>
 			<key>name</key>
 			<string>keyword.operator.bitwise.swift</string>
-		</dict>
-		<key>boolean-literal</key>
-		<dict>
-			<key>match</key>
-			<string>\b(true|false)\b</string>
-			<key>name</key>
-			<string>constant.language.boolean.swift</string>
 		</dict>
 		<key>builtin-class-type</key>
 		<dict>
@@ -290,6 +281,13 @@
 			<string>\b(BooleanLiteralType|StringLiteralType|C(Bool|S(hort|ignedChar)|Char(16|32)?|Int|Double|Unsigned(Short|Char|Int|Long(Long)?)|Float|WideChar|Long(Long)?)|Int(Max|egerLiteralType)|U(nicodeScalarType|IntMax|Word)|PlaygroundQuickLook|ExtendedGraphemeClusterType|Void|Float(32|LiteralType|64)|Word|Any(Class)?)\b</string>
 			<key>name</key>
 			<string>support.type.swift</string>
+		</dict>
+		<key>closure-parameter</key>
+		<dict>
+			<key>match</key>
+			<string>\$[0-9]+</string>
+			<key>name</key>
+			<string>variable.other.closure-parameter.swift</string>
 		</dict>
 		<key>coalescing-operator</key>
 		<dict>
@@ -531,12 +529,12 @@
 				</dict>
 			</dict>
 		</dict>
-		<key>comparative-operator</key>
+		<key>comparison-operator</key>
 		<dict>
 			<key>match</key>
 			<string>(?&lt;![/=\-+!*%&lt;&gt;&amp;|\^~.])((=|!)==?|(&lt;|&gt;)=?|~=)(?![/=\-+!*%&lt;&gt;&amp;|\^~.])</string>
 			<key>name</key>
-			<string>keyword.operator.comparative.swift</string>
+			<string>keyword.operator.comparison.swift</string>
 		</dict>
 		<key>custom-operator</key>
 		<dict>
@@ -583,7 +581,7 @@
 		<key>function-declaration</key>
 		<dict>
 			<key>begin</key>
-			<string>\b(func)\s+(\B\$[0-9]+|\b[\w^\d][\w\d]*\b|\B`[\w^\d][\w\d]*`\B|[/=\-+!*%&lt;&gt;&amp;|\^~.]+)\s*(?=\(|&lt;)</string>
+			<string>\b(func)\s+(\b[\w^\d][\w\d]*\b|\B`[\w^\d][\w\d]*`\B|[/=\-+!*%&lt;&gt;&amp;|\^~.]+)\s*(?=\(|&lt;)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -709,15 +707,6 @@
 					<string>$self</string>
 				</dict>
 			</array>
-		</dict>
-		<key>identifier</key>
-		<dict>
-			<key>comment</key>
-			<string>identifier</string>
-			<key>match</key>
-			<string>(\B\$[0-9]+|\b[\w^\d][\w\d]*\b|\B`[\w^\d][\w\d]*`\B)</string>
-			<key>name</key>
-			<string>meta.identifier.swift</string>
 		</dict>
 		<key>import-declaration</key>
 		<dict>
@@ -864,12 +853,16 @@
 					<string>#string-literal</string>
 				</dict>
 				<dict>
-					<key>include</key>
-					<string>#boolean-literal</string>
+					<key>match</key>
+					<string>\b(true|false)\b</string>
+					<key>name</key>
+					<string>constant.language.boolean.swift</string>
 				</dict>
 				<dict>
-					<key>include</key>
-					<string>#nil-literal</string>
+					<key>match</key>
+					<string>\bnil\b</string>
+					<key>name</key>
+					<string>constant.language.nil.swift</string>
 				</dict>
 				<dict>
 					<key>comment</key>
@@ -887,13 +880,6 @@
 			<string>(?&lt;![/=\-+!*%&lt;&gt;&amp;|\^~.])(!|&amp;&amp;|\|\|)(?![/=\-+!*%&lt;&gt;&amp;|\^~.])</string>
 			<key>name</key>
 			<string>keyword.operator.logical.swift</string>
-		</dict>
-		<key>nil-literal</key>
-		<dict>
-			<key>match</key>
-			<string>\bnil\b</string>
-			<key>name</key>
-			<string>constant.language.nil.swift</string>
 		</dict>
 		<key>numeric-literal</key>
 		<dict>
@@ -999,7 +985,7 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#comparative-operator</string>
+					<string>#comparison-operator</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -1048,43 +1034,6 @@
 				<dict>
 					<key>include</key>
 					<string>#custom-operator</string>
-				</dict>
-			</array>
-		</dict>
-		<key>optional-type</key>
-		<dict>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>support.type.optional.swift</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.optional.begin.swift</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>(&gt;)</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.optional.end.swift</string>
-				</dict>
-			</dict>
-			<key>match</key>
-			<string>\b(Optional)(&lt;)</string>
-			<key>name</key>
-			<string>meta.optional.swift</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>$self</string>
 				</dict>
 			</array>
 		</dict>
@@ -1142,43 +1091,6 @@
 					<key>match</key>
 					<string>\b([\w^\d][\w\d]*)\b\s+\b([\w^\d][\w\d]*)\b</string>
 				</dict>
-				<dict>
-					<key>include</key>
-					<string>$self</string>
-				</dict>
-			</array>
-		</dict>
-		<key>protocol-composition-type</key>
-		<dict>
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>support.type.protocol.swift</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.protocol.begin.swift</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>(&gt;)</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.protocol.end.swift</string>
-				</dict>
-			</dict>
-			<key>match</key>
-			<string>\b(protocol)(&lt;)</string>
-			<key>name</key>
-			<string>meta.protocol.swift</string>
-			<key>patterns</key>
-			<array>
 				<dict>
 					<key>include</key>
 					<string>$self</string>
@@ -1278,13 +1190,6 @@
 			<string>^(#!).*$</string>
 			<key>name</key>
 			<string>comment.line.shebang.swift</string>
-		</dict>
-		<key>storage-type</key>
-		<dict>
-			<key>match</key>
-			<string>\b(var|func|let|class|enum|struct|protocol|extension|typealias)\b</string>
-			<key>name</key>
-			<string>storage.type.swift</string>
 		</dict>
 		<key>string-literal</key>
 		<dict>
@@ -1418,14 +1323,6 @@
 				<dict>
 					<key>include</key>
 					<string>#builtin-type</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#optional-type</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#protocol-composition-type</string>
 				</dict>
 				<dict>
 					<key>match</key>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -580,26 +580,6 @@
 				</dict>
 			</array>
 		</dict>
-		<key>floating-point-literal</key>
-		<dict>
-			<key>name</key>
-			<string>constant.numeric.floating-point.swift</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>comment</key>
-					<string>floating-point-literal -&gt; (decimal-literal)(decimal-fraction)?(decimal-exponent)?</string>
-					<key>match</key>
-					<string>\b([0-9][0-9_]*)(\.([0-9][0-9_]*))?([eE][+\-]?([0-9][0-9_]*))?\b</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>floating-point-literal -&gt; (hexadecimal-literal)(hexadecimal-fraction)?(hexadecimal-exponent)</string>
-					<key>match</key>
-					<string>\b(0x\h[\h_]*)(\.(0x\h[\h_]*))?([pP][+\-]?(0x\h[\h_]*))\b</string>
-				</dict>
-			</array>
-		</dict>
 		<key>function-declaration</key>
 		<dict>
 			<key>begin</key>
@@ -773,46 +753,6 @@
 			<key>name</key>
 			<string>keyword.operator.increment-or-decrement.swift</string>
 		</dict>
-		<key>integer-literal</key>
-		<dict>
-			<key>name</key>
-			<string>constant.numeric.integer.swift</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>comment</key>
-					<string>binary-literal</string>
-					<key>match</key>
-					<string>(\B\-|\b)(0b[01][01_]*)\b</string>
-					<key>name</key>
-					<string>constant.numeric.integer.binary.swift</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>octal-literal</string>
-					<key>match</key>
-					<string>(\B\-|\b)(0o[0-7][0-7_]*)\b</string>
-					<key>name</key>
-					<string>constant.numeric.integer.octal.swift</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>decimal-literal</string>
-					<key>match</key>
-					<string>(\B\-|\b)([0-9][0-9_]*)\b</string>
-					<key>name</key>
-					<string>constant.numeric.integer.decimal.swift</string>
-				</dict>
-				<dict>
-					<key>comment</key>
-					<string>hexadecimal-literal</string>
-					<key>match</key>
-					<string>(\B\-|\b)(0x\h[\h_]*)\b</string>
-					<key>name</key>
-					<string>constant.numeric.integer.hexadecimal.swift</string>
-				</dict>
-			</array>
-		</dict>
 		<key>keyword</key>
 		<dict>
 			<key>patterns</key>
@@ -843,7 +783,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(?:do|catch|throws?|rethrows|try)\b|try[?!]\B</string>
+					<string>\b(?:do|catch|throws?|rethrows|try)\b|\btry[?!]\B</string>
 					<key>name</key>
 					<string>keyword.control.exception.swift</string>
 				</dict>
@@ -917,11 +857,7 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#integer-literal</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#floating-point-literal</string>
+					<string>#numeric-literal</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -958,6 +894,104 @@
 			<string>\bnil\b</string>
 			<key>name</key>
 			<string>constant.language.nil.swift</string>
+		</dict>
+		<key>numeric-literal</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>comment</key>
+					<string>0.1, -4_2.5, 6.022e23, 10E-5</string>
+					<key>match</key>
+					<string>(\B\-|\b)(?&lt;![^.]\.)[0-9][0-9_]*(?:\.[0-9][0-9_]*)?(?:[eE][+\-]?[0-9][0-9_]*)?\b(?!\.[0-9])</string>
+					<key>name</key>
+					<string>constant.numeric.float.decimal.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>-0x1.ap2_3, 0x31p-4</string>
+					<key>match</key>
+					<string>(\B\-|\b)(?&lt;![^.]\.)(0x\h[\h_]*)(?:\.\h[\h_]*)?[pP][+\-]?[0-9][0-9_]*\b(?!\.[0-9])</string>
+					<key>name</key>
+					<string>constant.numeric.float.hexadecimal.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>0x1p, 0x1p_2, 0x1.5pa, 0x1.1p+1f, 0x1pz</string>
+					<key>match</key>
+					<string>(\B\-|\b)(?&lt;![^.]\.)(0x\h[\h_]*)(?:\.\h[\h_]*)?(?:[pP][+\-]?\w*)\b(?!\.[0-9])</string>
+					<key>name</key>
+					<string>invalid.illegal.numeric.float.invalid-exponent.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>0x1.5w (note that 0x1.f may be a valid expression)</string>
+					<key>match</key>
+					<string>(\B\-|\b)(?&lt;![^.]\.)(0x\h[\h_]*)\.[0-9][\w.]*</string>
+					<key>name</key>
+					<string>invalid.illegal.numeric.float.missing-exponent.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>-.5, .2f (note that 1.-.5 may be a valid expression)</string>
+					<key>match</key>
+					<string>(?&lt;=\s|^)\-?\.[0-9][\w.]*</string>
+					<key>name</key>
+					<string>invalid.illegal.numeric.float.missing-leading-zero.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>0b_0_1, 0x_1p+3q</string>
+					<key>match</key>
+					<string>(\B\-|\b)0[box]_[\h_]*(?:[pPeE][+-]?\w+)?[\w.]+</string>
+					<key>name</key>
+					<string>invalid.illegal.numeric.leading-underscore.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>tuple positional member: not really a numeric literal, but not invalid</string>
+					<key>match</key>
+					<string>(?&lt;=[^.]\.)[0-9][0-9_]*\b</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>0b010, 0b1_0</string>
+					<key>match</key>
+					<string>(\B\-|\b)(?&lt;![^.]\.)0b[01][01_]*\b(?!\.[0-9])</string>
+					<key>name</key>
+					<string>constant.numeric.integer.binary.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>0o1, 0o7_3</string>
+					<key>match</key>
+					<string>(\B\-|\b)(?&lt;![^.]\.)0o[0-7][0-7_]*\b(?!\.[0-9])</string>
+					<key>name</key>
+					<string>constant.numeric.integer.octal.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>02, 3_456</string>
+					<key>match</key>
+					<string>(\B\-|\b)(?&lt;![^.]\.)[0-9][0-9_]*\b(?!\.[0-9])</string>
+					<key>name</key>
+					<string>constant.numeric.integer.decimal.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>0x4, 0xF_7</string>
+					<key>match</key>
+					<string>(\B\-|\b)(?&lt;![^.]\.)0x\h[\h_]*\b(?!\.[0-9])</string>
+					<key>name</key>
+					<string>constant.numeric.integer.hexadecimal.swift</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(\B\-|\b)[0-9][\w.]*</string>
+					<key>name</key>
+					<string>invalid.illegal.numeric.other.swift</string>
+				</dict>
+			</array>
 		</dict>
 		<key>operator</key>
 		<dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -1108,6 +1108,10 @@
 			<key>patterns</key>
 			<array>
 				<dict>
+					<key>include</key>
+					<string>#comment</string>
+				</dict>
+				<dict>
 					<key>captures</key>
 					<dict>
 						<key>1</key>
@@ -1152,10 +1156,6 @@
 					</dict>
 					<key>match</key>
 					<string>\b(assignment)\b</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#comment</string>
 				</dict>
 			</array>
 		</dict>
@@ -1225,6 +1225,10 @@
 					</dict>
 					<key>patterns</key>
 					<array>
+						<dict>
+							<key>include</key>
+							<string>#comment</string>
+						</dict>
 						<dict>
 							<key>captures</key>
 							<dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -68,14 +68,6 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#builtin-static-property</string>
-		</dict>
-		<dict>
-			<key>include</key>
-			<string>#builtin-constant</string>
-		</dict>
-		<dict>
-			<key>include</key>
 			<string>#section-punctuation</string>
 		</dict>
 	</array>
@@ -184,82 +176,186 @@
 			<key>name</key>
 			<string>support.class.swift</string>
 		</dict>
-		<key>builtin-constant</key>
-		<dict>
-			<key>comment</key>
-			<string>Process is really an enum, but it acts like a constant</string>
-			<key>match</key>
-			<string>\bProcess\b</string>
-			<key>name</key>
-			<string>support.constant.swift</string>
-		</dict>
 		<key>builtin-enum-type</key>
 		<dict>
-			<key>comment</key>
-			<string>Builtin enum types</string>
-			<key>match</key>
-			<string>\b(MirrorDisposition|Bit|ImplicitlyUnwrappedOptional|Optional|UnicodeDecodingResult|QuickLookObject|FloatingPointClassification)\b</string>
-			<key>name</key>
-			<string>support.type.swift</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>comment</key>
+					<string>Process is an enum, but it acts like a constant</string>
+					<key>match</key>
+					<string>\b(?:Process|CommandLine)\b</string>
+					<key>name</key>
+					<string>support.constant.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>The return type of a function that never returns</string>
+					<key>match</key>
+					<string>\bNever\b</string>
+					<key>name</key>
+					<string>support.constant.never.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Enum types in the standard library in Swift 3</string>
+					<key>match</key>
+					<string>\b(?:ImplicitlyUnwrappedOptional|Representation|MemoryLayout|FloatingPointClassification|SetIndexRepresentation|SetIteratorRepresentation|FloatingPointRoundingRule|UnicodeDecodingResult|Optional|DictionaryIndexRepresentation|AncestorRepresentation|DisplayStyle|PlaygroundQuickLook|Never|FloatingPointSign|Bit|DictionaryIteratorRepresentation)\b</string>
+					<key>name</key>
+					<string>support.type.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Enum types in the standard library in Swift 2 only</string>
+					<key>match</key>
+					<string>\b(?:MirrorDisposition|QuickLookObject)\b</string>
+					<key>name</key>
+					<string>support.type.swift</string>
+				</dict>
+			</array>
 		</dict>
 		<key>builtin-function</key>
 		<dict>
-			<key>comment</key>
-			<string>Functions provided in the standard library; found by searching ^[ \t]+func\s+(\w+?)[&lt;(]</string>
-			<key>match</key>
-			<string>(?&lt;=\.)(s(tartsWith|ort|u(ccessor|perclassMirror|btract)|amePositionIn)|has(Suffix|Prefix)|next(Object)?|c(haracterAtIndex|o(ntains|untByEnumeratingWithState|pyWithZone)|ustom(Mirror|PlaygroundQuickLook)|lamp)|t(o(IntMax|Opaque|UIntMax)|ake(RetainedValue|UnretainedValue))|i(s(S(trictSu(persetOf|bsetOf)|u(persetOf|bsetOf))|DisjointWith|EmptyInput|ASCII)|n(tersect|itialize(From)?|dex(Of|ForKey)))|object(Enumerator|ForKey|AtIndex)|d(istanceTo|e(s(cendant|troy)|alloc))|un(ion|derestimateCount)|join|p(ut|redecessor)|e(scape|numerate|lementsEqual|xclusiveOr)|keyEnumerator|f(ilter|latMap)|w(ith(CString|U(nsafe(MutablePointer(s|To(Elements|Value))|BufferPointer)|TF8Buffer))|riteTo)|le(ngth|xicographicalCompare)|a(ssign(BackwardFrom|From)|dvancedBy|utorelease)|re(tain|duce|verse|questNativeBuffer|lease)|ge(nerate|t(Mirror|Objects))|m(inElement|ove(Initialize(BackwardFrom|From)|AssignFrom)?|ember|a(p|xElement)))\b</string>
-			<key>name</key>
-			<string>support.function.swift</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\btype(?=\(of:)</string>
+					<key>name</key>
+					<string>support.function.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Member functions in the standard library in Swift 3 which may be used with trailing closures</string>
+					<key>match</key>
+					<string>(?&lt;=\.)(?:s(?:tarts|ort(?:ed)?|plit)|next|c(?:ontains|reate)|index|partition|e(?:ncode|lementsEqual)|f(?:i(?:lter|rst)|orEach|latMap)|with(?:M(?:utableCharacters|emoryRebound)|CString|U(?:nsafe(?:Mutable(?:BufferPointer|Pointer(?:s|To(?:Header|Elements)))|BufferPointer)|TF8Buffer))|lexicographicallyPrecedes|reduce|m(?:in|a(?:p|x)))\b</string>
+					<key>name</key>
+					<string>support.function.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Member functions in the standard library in Swift 3</string>
+					<key>match</key>
+					<string>(?&lt;=\.)(?:s(?:ymmetricDifference|t(?:oreBytes|artsWith|ride)|ortInPlace|u(?:ccessor|ffix|btract(?:ing|InPlace|WithOverflow)?)|quareRoot|amePosition)|h(?:oldsUnique(?:Reference|OrPinnedReference)|as(?:Suffix|Prefix))|negate(?:d)?|c(?:o(?:untByEnumerating|py(?:Bytes)?)|lamp(?:ed)?)|t(?:o(?:IntMax|Opaque|UIntMax)|ake(?:RetainedValue|UnretainedValue)|r(?:uncatingRemainder|a(?:nscodedLength|ilSurrogate)))|i(?:s(?:MutableAndUniquelyReferenced(?:OrPinned)?|S(?:trictSu(?:perset(?:Of)?|bset(?:Of)?)|u(?:perset(?:Of)?|bset(?:Of)?))|Continuation|T(?:otallyOrdered|railSurrogate)|Disjoint(?:With)?|Unique(?:Reference|lyReferenced(?:OrPinned)?)|Equal|Le(?:ss(?:ThanOrEqualTo)?|adSurrogate))|n(?:sert(?:ContentsOf)?|tersect(?:ion|InPlace)?|itialize(?:Memory|From)?|dex(?:Of|ForKey)))|o(?:verlaps|bjectAt)|d(?:i(?:stance(?:To)?|vide(?:d|WithOverflow)?)|e(?:s(?:cendant|troy)|code(?:CString)?|initialize|alloc(?:ate(?:Capacity)?)?)|rop(?:First|Last))|u(?:n(?:ion(?:InPlace)?|derestimateCount|wrappedOrError)|p(?:date(?:Value)?|percased))|join(?:ed|WithSeparator)|p(?:op(?:First|Last)|ass(?:Retained|Unretained)|re(?:decessor|fix))|e(?:scape(?:d)?|numerate(?:d)?|xclusiveOr(?:InPlace)?)|f(?:orm(?:Remainder|S(?:ymmetricDifference|quareRoot)|TruncatingRemainder|In(?:tersection|dex)|Union)|latten|rom(?:CString(?:RepairingIllFormedUTF8)?|Opaque))|w(?:idth|rite(?:To)?)|l(?:o(?:wercased|ad)|e(?:adSurrogate|xicographicalCompare))|a(?:ss(?:ign(?:BackwardFrom|From)?|umingMemoryBound)|d(?:d(?:ing(?:Product)?|Product|WithOverflow)?|vanced(?:By)?)|utorelease|ppend(?:ContentsOf)?|lloc(?:ate)?|bs)|r(?:ound(?:ed)?|e(?:serveCapacity|tain|place(?:Range|Subrange)?|verse(?:d)?|quest(?:NativeBuffer|UniqueMutableBackingBuffer)|lease|m(?:ove(?:Range|Subrange|Value(?:ForKey)?|First|Last|A(?:tIndex|ll))?|ainder(?:WithOverflow)?)))|ge(?:nerate|t(?:Objects|Element))|m(?:in(?:imum(?:Magnitude)?|Element)|ove(?:Initialize(?:Memory|BackwardFrom|From)?|Assign(?:From)?)?|ultipl(?:y(?:WithOverflow)?|ied)|easure|a(?:ke(?:Iterator|Description)|x(?:imum(?:Magnitude)?|Element)))|bindMemory)\s*(?=\()</string>
+					<key>name</key>
+					<string>support.function.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Member functions in the standard library in Swift 2 only</string>
+					<key>match</key>
+					<string>(?&lt;=\.)(?:s(?:uperclassMirror|amePositionIn)|nextObject|c(?:haracterAtIndex|o(?:untByEnumeratingWithState|pyWithZone)|ustom(?:Mirror|PlaygroundQuickLook))|is(?:EmptyInput|ASCII)|object(?:Enumerator|ForKey|AtIndex)|join|put|keyEnumerator|withUnsafeMutablePointerToValue|length|getMirror|m(?:oveInitializeAssignFrom|ember))(?=\()</string>
+					<key>name</key>
+					<string>support.function.swift</string>
+				</dict>
+			</array>
 		</dict>
 		<key>builtin-global-function</key>
 		<dict>
-			<key>comment</key>
-			<string>Global functions provided in the standard library; found by searching ^func\s+(\w+?)[&lt;(]</string>
-			<key>match</key>
-			<string>\btype(?=\(of\:)|\b(s(tride(of(Value)?)?|izeof(Value)?|ort|uffix|pli(ce|t)|wap)|numericCast|transcode|i(sUniquelyReferenced(NonObjC)?|nsert)|zip|overlaps|d(istance|ump|ebugPrint|rop(First|Last))|unsafe(BitCast|Downcast|Unwrap|AddressOf)|join|pr(int|e(condition|fix))|extend|with(Unsafe(MutablePointer(s)?|Pointer(s)?)|ExtendedLifetime|VaList)|lazy|a(ssert(ionFailure)?|nyGenerator|dvance|lignof(Value)?|bs)|re(flect|adLine|move(Range|Last|A(tIndex|ll)))|getVaList|m(in|ax))\b</string>
-			<key>name</key>
-			<string>support.function.swift</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>comment</key>
+					<string>Global functions available in Swift 3 which may be used with trailing closures</string>
+					<key>match</key>
+					<string>\b(?:anyGenerator)\b</string>
+					<key>name</key>
+					<string>support.function.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Global functions available in Swift 3</string>
+					<key>match</key>
+					<string>\b(?:s(?:tride(?:of(?:Value)?)?|izeof(?:Value)?|equence|wap)|numericCast|transcode|is(?:UniquelyReferenced(?:NonObjC)?|KnownUniquelyReferenced)|zip|d(?:ump|ebugPrint)|unsafe(?:BitCast|Downcast|Unwrap|Address(?:Of)?)|pr(?:int|econdition(?:Failure)?)|fatalError|with(?:Unsafe(?:MutablePointer|Pointer)|ExtendedLifetime|VaList)|a(?:ssert(?:ionFailure)?|lignof(?:Value)?|bs)|re(?:peatElement|adLine)|getVaList|m(?:in|ax))\s*(?=\()</string>
+					<key>name</key>
+					<string>support.function.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Global functions available in Swift 2 only</string>
+					<key>match</key>
+					<string>\b(?:s(?:ort|uffix|pli(?:ce|t))|insert|overlaps|d(?:istance|rop(?:First|Last))|join|prefix|extend|withUnsafe(?:MutablePointers|Pointers)|lazy|advance|re(?:flect|move(?:Range|Last|A(?:tIndex|ll))))\s*(?=\()</string>
+					<key>name</key>
+					<string>support.function.swift</string>
+				</dict>
+			</array>
 		</dict>
 		<key>builtin-property</key>
 		<dict>
-			<key>comment</key>
-			<string>Properties provided in the standard library; found by searching ^\s+var\s+(\w+?)\W</string>
-			<key>match</key>
-			<string>(?&lt;=\.)(s(t(art(Index)?|ringValue)|ummary)|has(hValue|PointerRepresentation)|nulTerminatedUTF8|c(haracters|ount|apacity)|i(s(S(ign(Minus|aling)|ubnormal)|N(ormal|aN)|Infinite|Zero|Empty|Finite|ASCII)|ndices|dentity)|o(wner|bjectIdentifier)|d(isposition|e(scription|bugDescription))|u(nicodeScalar(s)?|tf(16|8(Start)?)|intValue|ppercaseString)|end(Index)?|value(s|Type)?|keys|quickLookObject|f(irst|loatingPointClass)|l(ittleEndian|owercaseString|ast)|a(llocatedElementCount|rray)|rawValue|memory|b(yteS(ize|wapped)|igEndian|oolValue|uffer|aseAddress))\b</string>
-			<key>name</key>
-			<string>support.variable.swift</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>(?&lt;=\bProcess\.|\bCommandLine\.)(arguments|argc|unsafeArgv)</string>
+					<key>name</key>
+					<string>support.variable.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Properties in the standard library in Swift 3</string>
+					<key>match</key>
+					<string>(?&lt;=\.)(?:s(?:t(?:artIndex|ri(?:ngValue|de))|i(?:ze|gn(?:BitIndex|ificand(?:Bit(?:Count|Pattern)|Width)?|alingNaN)?)|u(?:perclassMirror|mmary|bscriptBaseAddress))|h(?:eader|as(?:hValue|PointerRepresentation))|n(?:ulTerminatedUTF8|ext(?:Down|Up)|a(?:n|tiveOwner))|c(?:haracters|ount(?:TrailingZeros)?|ustom(?:Mirror|PlaygroundQuickLook)|apacity)|i(?:s(?:S(?:ign(?:Minus|aling(?:NaN)?)|ubnormal)|N(?:ormal|aN)|Canonical|Infinite|Zero|Empty|Finite|ASCII)|n(?:dices|finity)|dentity)|owner|de(?:scription|bugDescription)|u(?:n(?:safelyUnwrapped|icodeScalar(?:s)?|derestimatedCount)|tf(?:16|8(?:Start|C(?:String|odeUnitCount))?)|intValue|ppercaseString|lp(?:OfOne)?)|p(?:i|ointee)|e(?:ndIndex|lements|xponent(?:Bit(?:Count|Pattern))?)|value(?:s)?|keys|quietNaN|f(?:irst(?:ElementAddress(?:IfContiguous)?)?|loatingPointClass)|l(?:ittleEndian|owercaseString|eastNo(?:nzeroMagnitude|rmalMagnitude)|a(?:st|zy))|a(?:l(?:ignment|l(?:ocatedElementCount|Zeros))|rray(?:PropertyIsNativeTypeChecked)?)|ra(?:dix|wValue)|greatestFiniteMagnitude|m(?:in|emory|ax)|b(?:yteS(?:ize|wapped)|i(?:nade|tPattern|gEndian)|uffer|ase(?:Address)?))\b</string>
+					<key>name</key>
+					<string>support.variable.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Properties in the standard library in Swift 2 only</string>
+					<key>match</key>
+					<string>(?&lt;=\.)(?:boolValue|disposition|end|objectIdentifier|quickLookObject|start|valueType)\b</string>
+					<key>name</key>
+					<string>support.variable.swift</string>
+				</dict>
+			</array>
 		</dict>
 		<key>builtin-protocol-type</key>
 		<dict>
-			<key>comment</key>
-			<string>Builtin protocol types</string>
-			<key>match</key>
-			<string>\b(Ra(n(domAccessIndexType|geReplaceableCollectionType)|wRepresentable)|GeneratorType|M(irror(Type|PathType)|utable(Sliceable|CollectionType))|B(i(twiseOperationsType|directionalIndexType)|oolean(Type|LiteralConvertible))|S(tr(i(ng(InterpolationConvertible|LiteralConvertible)|deable)|eamable)|i(nkType|gned(NumberType|IntegerType))|e(tAlgebraType|quenceType)|liceable)|Hashable|NilLiteralConvertible|C(o(llectionType|mparable)|ustom(Reflectable|StringConvertible|DebugStringConvertible|PlaygroundQuickLookable|LeafReflectable)|VarArgType)|Inte(rvalType|ger(Type|LiteralConvertible|ArithmeticType))|O(utputStreamType|ptionSetType)|DictionaryLiteralConvertible|Un(signedIntegerType|icode(ScalarLiteralConvertible|CodecType))|E(quatable|rrorType|xten(sibleCollectionType|dedGraphemeClusterLiteralConvertible))|F(orwardIndexType|loat(ingPointType|LiteralConvertible))|A(ny(CollectionType|Object)|rrayLiteralConvertible|bsoluteValuable))\b</string>
-			<key>name</key>
-			<string>support.type.swift</string>
-		</dict>
-		<key>builtin-static-property</key>
-		<dict>
-			<key>comment</key>
-			<string>Static properties provided in the standard library; found by searching ^\s*(class|static)\s+var\s+(\w+?)\W</string>
-			<key>match</key>
-			<string>(?&lt;=\.)(infinity|NaN|quietNaN|allZeros|m(in|ax))\b|(?&lt;=\bProcess\.)(arguments|argc|unsafeArgv)\b</string>
-			<key>name</key>
-			<string>support.variable.swift</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>comment</key>
+					<string>Protocols in the standard library in Swift 3</string>
+					<key>match</key>
+					<string>\b(?:Ra(?:n(?:domAccess(?:Collection|Indexable)|geReplaceable(?:Collection|Indexable))|wRepresentable)|M(?:irrorPath|utable(?:Collection|Indexable))|Bi(?:naryFloatingPoint|twiseOperations|directional(?:Collection|Indexable))|S(?:tr(?:ideable|eamable)|igned(?:Number|Integer)|e(?:tAlgebra|quence))|Hashable|C(?:o(?:llection|mparable)|ustom(?:Reflectable|StringConvertible|DebugStringConvertible|PlaygroundQuickLookable|LeafReflectable)|VarArg)|TextOutputStream|I(?:n(?:teger(?:Arithmetic)?|dexable(?:Base)?)|teratorProtocol)|OptionSet|Un(?:signedInteger|icodeCodec)|E(?:quatable|rror|xpressibleBy(?:BooleanLiteral|String(?:Interpolation|Literal)|NilLiteral|IntegerLiteral|DictionaryLiteral|UnicodeScalarLiteral|ExtendedGraphemeClusterLiteral|FloatLiteral|ArrayLiteral))|FloatingPoint|L(?:osslessStringConvertible|azy(?:SequenceProtocol|CollectionProtocol))|A(?:nyObject|bsoluteValuable))\b</string>
+					<key>name</key>
+					<string>support.type.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Protocols in the standard library in Swift 2 only</string>
+					<key>match</key>
+					<string>\b(?:Ran(?:domAccessIndexType|geReplaceableCollectionType)|GeneratorType|M(?:irror(?:Type|PathType)|utable(?:Sliceable|CollectionType))|B(?:i(?:twiseOperationsType|directionalIndexType)|oolean(?:Type|LiteralConvertible))|S(?:tring(?:InterpolationConvertible|LiteralConvertible)|i(?:nkType|gned(?:NumberType|IntegerType))|e(?:tAlgebraType|quenceType)|liceable)|NilLiteralConvertible|C(?:ollectionType|VarArgType)|Inte(?:rvalType|ger(?:Type|LiteralConvertible|ArithmeticType))|O(?:utputStreamType|ptionSetType)|DictionaryLiteralConvertible|Un(?:signedIntegerType|icode(?:ScalarLiteralConvertible|CodecType))|E(?:rrorType|xten(?:sibleCollectionType|dedGraphemeClusterLiteralConvertible))|F(?:orwardIndexType|loat(?:ingPointType|LiteralConvertible))|A(?:nyCollectionType|rrayLiteralConvertible))\b</string>
+					<key>name</key>
+					<string>support.type.swift</string>
+				</dict>
+			</array>
 		</dict>
 		<key>builtin-struct-type</key>
 		<dict>
-			<key>comment</key>
-			<string>Builtin struct types</string>
-			<key>match</key>
-			<string>\b(R(e(peat|verse(RandomAccess(Collection|Index)|Collection|Index))|a(nge(Generator)?|wByte))|Generator(Sequence|OfOne)|M(irror|a(nagedBufferPointer|p(Generator|Sequence|Collection)))|Bool|S(t(aticString|ri(ng|deT(hrough(Generator)?|o(Generator)?)))|inkOf|et(Generator|Index)?)|HalfOpenInterval|C(haracter|o(ntiguousArray|llectionOfOne)|OpaquePointer|losedInterval|VaListPointer)|In(t(16|8|32|64)?|dexingGenerator)|Zip2(Generator|Sequence)|ObjectIdentifier|D(ictionary(Generator|Index|Literal)?|ouble)|U(n(safe(Mutable(BufferPointer|Pointer)|BufferPointer(Generator)?|Pointer)|icodeScalar|managed)|TF(16|8|32)|Int(16|8|32|64)?)|PermutationGenerator|E(numerate(Generator|Sequence)|mpty(Generator|Collection))|F(ilter(Generator|Sequence|Collection(Index)?)|loat(80)?)|Lazy(RandomAccessCollection|BidirectionalCollection|Sequence|ForwardCollection)|A(ny(RandomAccess(Collection|Index)|Bidirectional(Collection|Index)|Sequence|Forward(Collection|Index))|utoreleasingUnsafeMutablePointer|rray(Slice)?))\b</string>
-			<key>name</key>
-			<string>support.type.swift</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>comment</key>
+					<string>Structs in the standard library in Swift 3</string>
+					<key>match</key>
+					<string>\b(?:R(?:e(?:peat(?:ed)?|versed(?:RandomAccess(?:Collection|Index)|Collection|Index))|an(?:domAccessSlice|ge(?:Replaceable(?:RandomAccessSlice|BidirectionalSlice|Slice)|Generator)?))|Generator(?:Sequence|OfOne)|M(?:irror|utable(?:Ran(?:domAccessSlice|geReplaceable(?:RandomAccessSlice|BidirectionalSlice|Slice))|BidirectionalSlice|Slice)|anagedBufferPointer)|B(?:idirectionalSlice|ool)|S(?:t(?:aticString|ri(?:ng|deT(?:hrough(?:Generator|Iterator)?|o(?:Generator|Iterator)?)))|et(?:I(?:ndex|terator))?|lice)|HalfOpenInterval|C(?:haracter(?:View)?|o(?:ntiguousArray|untable(?:Range|ClosedRange)|llectionOfOne)|OpaquePointer|losed(?:Range(?:I(?:ndex|terator))?|Interval)|VaListPointer)|I(?:n(?:t(?:16|8|32|64)?|d(?:ices|ex(?:ing(?:Generator|Iterator))?))|terator(?:Sequence|OverOne)?)|Zip2(?:Sequence|Iterator)|O(?:paquePointer|bjectIdentifier)|D(?:ictionary(?:I(?:ndex|terator)|Literal)?|ouble|efault(?:RandomAccessIndices|BidirectionalIndices|Indices))|U(?:n(?:safe(?:RawPointer|Mutable(?:RawPointer|BufferPointer|Pointer)|BufferPointer(?:Generator|Iterator)?|Pointer)|icodeScalar(?:View)?|foldSequence|managed)|TF(?:16(?:View)?|8(?:View)?|32)|Int(?:16|8|32|64)?)|Join(?:Generator|ed(?:Sequence|Iterator))|PermutationGenerator|E(?:numerate(?:Generator|Sequence|d(?:Sequence|Iterator))|mpty(?:Generator|Collection|Iterator))|Fl(?:oat(?:80)?|atten(?:Generator|BidirectionalCollection(?:Index)?|Sequence|Collection(?:Index)?|Iterator))|L(?:egacyChildren|azy(?:RandomAccessCollection|Map(?:RandomAccessCollection|Generator|BidirectionalCollection|Sequence|Collection|Iterator)|BidirectionalCollection|Sequence|Collection|Filter(?:Generator|BidirectionalCollection|Sequence|Collection|I(?:ndex|terator))))|A(?:ny(?:RandomAccessCollection|Generator|BidirectionalCollection|Sequence|Hashable|Collection|I(?:ndex|terator))|utoreleasingUnsafeMutablePointer|rray(?:Slice)?))\b</string>
+					<key>name</key>
+					<string>support.type.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Structs in the standard library in Swift 2 only</string>
+					<key>match</key>
+					<string>\b(?:R(?:everse(?:RandomAccess(?:Collection|Index)|Collection|Index)|awByte)|Map(?:Generator|Sequence|Collection)|S(?:inkOf|etGenerator)|Zip2Generator|DictionaryGenerator|Filter(?:Generator|Sequence|Collection(?:Index)?)|LazyForwardCollection|Any(?:RandomAccessIndex|BidirectionalIndex|Forward(?:Collection|Index)))\b</string>
+					<key>name</key>
+					<string>support.type.swift</string>
+				</dict>
+			</array>
 		</dict>
 		<key>builtin-type</key>
 		<dict>
 			<key>comment</key>
-			<string>Types provided in the standard library; found by searching ^(@objc\s+)?(struct|protocol|class|enum)\s+(\w+)[\s&lt;].+$</string>
+			<string>Types provided in the standard library</string>
 			<key>patterns</key>
 			<array>
 				<dict>
@@ -286,12 +382,25 @@
 		</dict>
 		<key>builtin-typealias</key>
 		<dict>
-			<key>comment</key>
-			<string>Builtin typealiases</string>
-			<key>match</key>
-			<string>\b(BooleanLiteralType|StringLiteralType|C(Bool|S(hort|ignedChar)|Char(16|32)?|Int|Double|Unsigned(Short|Char|Int|Long(Long)?)|Float|WideChar|Long(Long)?)|Int(Max|egerLiteralType)|U(nicodeScalarType|IntMax|Word)|PlaygroundQuickLook|ExtendedGraphemeClusterType|Void|Float(32|LiteralType|64)|Word|Any(Class)?)\b</string>
-			<key>name</key>
-			<string>support.type.swift</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>comment</key>
+					<string>Typealiases in the standard library in Swift 3</string>
+					<key>match</key>
+					<string>\b(?:Raw(?:Significand|Exponent|Value)|B(?:ooleanLiteralType|uffer|ase)|S(?:t(?:orage|r(?:i(?:ngLiteralType|de)|eam(?:1|2)))|ubSequence)|NativeBuffer|C(?:hild(?:ren)?|Bool|S(?:hort|ignedChar)|odeUnit|Char(?:16|32)?|Int|Double|Unsigned(?:Short|Char|Int|Long(?:Long)?)|Float|WideChar|Long(?:Long)?)|I(?:n(?:t(?:Max|egerLiteralType)|d(?:ices|ex(?:Distance)?))|terator)|Distance|U(?:n(?:icodeScalar(?:Type|Index|View|LiteralType)|foldFirstSequence)|TF(?:16(?:Index|View)|8Index)|IntMax)|E(?:lement(?:s)?|x(?:tendedGraphemeCluster(?:Type|LiteralType)|ponent))|V(?:oid|alue)|Key|Float(?:32|LiteralType|64)|AnyClass)\b</string>
+					<key>name</key>
+					<string>support.type.swift</string>
+				</dict>
+				<dict>
+					<key>comment</key>
+					<string>Typealiases in the standard library in Swift 2 only</string>
+					<key>match</key>
+					<string>\b(?:Generator|PlaygroundQuickLook|UWord|Word)\b</string>
+					<key>name</key>
+					<string>support.type.swift</string>
+				</dict>
+			</array>
 		</dict>
 		<key>closure-parameter</key>
 		<dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -848,6 +848,10 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#declaration-protocol</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#declaration-typealias</string>
 				</dict>
 				<dict>
@@ -1290,10 +1294,10 @@
 				</dict>
 			</array>
 		</dict>
-		<key>declaration-type</key>
+		<key>declaration-protocol</key>
 		<dict>
 			<key>begin</key>
-			<string>\b(class|struct|enum)\s+((?!\d)\w[\w\d]*\b|\B`(?!\d)\w[\w\d]*`\B)\s*(?=[{&lt;:])</string>
+			<string>\b(protocol)\s+((?!\d)\w[\w\d]*\b|\B`(?!\d)\w[\w\d]*`\B)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -1308,7 +1312,75 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(?&lt;=\})|$</string>
+			<string>(?&lt;=\})</string>
+			<key>name</key>
+			<string>meta.definition.type.protocol.swift</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#comment</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#inheritance-clause</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>(\{)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.type.begin.swift</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(\})</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.type.end.swift</string>
+						</dict>
+					</dict>
+					<key>name</key>
+					<string>meta.definition.type.protocol.body.swift</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>$self</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#nested-braces</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+		</dict>
+		<key>declaration-type</key>
+		<dict>
+			<key>begin</key>
+			<string>\b(class|struct|enum)\s+((?!\d)\w[\w\d]*\b|\B`(?!\d)\w[\w\d]*`\B)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.$1.swift</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.type.$1.swift</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?&lt;=\})</string>
 			<key>name</key>
 			<string>meta.definition.type.$1.swift</string>
 			<key>patterns</key>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -672,6 +672,14 @@
 					<key>include</key>
 					<string>#function-declaration</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#operator-declaration</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#precedence-group-declaration</string>
+				</dict>
 			</array>
 		</dict>
 		<key>function-declaration</key>
@@ -886,7 +894,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(?:inout|static|final|lazy|mutating|nonmutating|optional|indirect|required|override|dynamic|convenience)\b</string>
+					<string>\b(?:inout|static|final|lazy|mutating|nonmutating|optional|indirect|required|override|dynamic|convenience|infix|prefix|postfix)\b</string>
 					<key>name</key>
 					<string>storage.modifier.swift</string>
 				</dict>
@@ -909,12 +917,6 @@
 					<string>\b(?:weak\b|unowned(?:\((?:un)?safe\))?)</string>
 					<key>name</key>
 					<string>keyword.other.capture-specifier.swift</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>\b(?:operator|prefix|infix|postfix|precedencegroup|higherThan|lowerThan|left|associativity|right|precedence)\b</string>
-					<key>name</key>
-					<string>keyword.other.operator.swift</string>
 				</dict>
 				<dict>
 					<key>match</key>
@@ -1133,6 +1135,133 @@
 				</dict>
 			</array>
 		</dict>
+		<key>operator-declaration</key>
+		<dict>
+			<key>begin</key>
+			<string>\b(prefix|infix|postfix)?\s+(operator)\s+([/=\-+!*%&lt;&gt;&amp;|\^~.]+)\s*(?=[:{])</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.modifier.swift</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.function.operator.swift</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.operator.custom.swift</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?!\G)</string>
+			<key>name</key>
+			<string>meta.definition.operator.swift</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#operator-declaration-swift2</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#operator-declaration-swift3</string>
+				</dict>
+			</array>
+		</dict>
+		<key>operator-declaration-swift2</key>
+		<dict>
+			<key>begin</key>
+			<string>(\{)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.operator.begin.swift</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(\})</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.operator.end.swift</string>
+				</dict>
+			</dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>storage.modifier.swift</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.operator.associativity.swift</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>\b(associativity)\s+(left|right)\b</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>storage.modifier.swift</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>constant.numeric.integer.swift</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>\b(precedence)\s+([0-9]+)\b</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>storage.modifier.swift</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>\b(assignment)\b</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comment</string>
+				</dict>
+			</array>
+		</dict>
+		<key>operator-declaration-swift3</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.other.inherited-class.swift</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(:)\s*([\w^\d][\w\d]*\b|\B`[\w^\d][\w\d]*`\B)</string>
+		</dict>
 		<key>overflow-operator</key>
 		<dict>
 			<key>match</key>
@@ -1190,6 +1319,107 @@
 				<dict>
 					<key>include</key>
 					<string>$self</string>
+				</dict>
+			</array>
+		</dict>
+		<key>precedence-group-declaration</key>
+		<dict>
+			<key>begin</key>
+			<string>\b(precedencegroup)\s+([\w^\d][\w\d]*\b|\B`[\w^\d][\w\d]*`\B)\s*(?=\{)</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.precedencegroup.swift</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.type.precedencegroup.swift</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>(?!\G)</string>
+			<key>name</key>
+			<string>meta.definition.precedencegroup.swift</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>(\{)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.precedencegroup.begin.swift</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(\})</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.precedencegroup.end.swift</string>
+						</dict>
+					</dict>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>storage.modifier.swift</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>entity.other.inherited-class.swift</string>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>\b(higherThan|lowerThan)\s*:\s*([\w^\d][\w\d]*\b|\B`[\w^\d][\w\d]*`\B)</string>
+						</dict>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>storage.modifier.swift</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>keyword.other.operator.associativity.swift</string>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>\b(associativity)\b(?:\s*:\s*(right|left)\b)?</string>
+						</dict>
+						<dict>
+							<key>captures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>storage.modifier.swift</string>
+								</dict>
+								<key>2</key>
+								<dict>
+									<key>name</key>
+									<string>constant.language.boolean.swift</string>
+								</dict>
+							</dict>
+							<key>match</key>
+							<string>\b(assignment)\b(?:\s*:\s*(true|false)\b)?</string>
+						</dict>
+					</array>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
Lots of stuff!
- Cleanup/improvement/modernizations of keywords
- More thorough support for numeric literals, including `invalid.illegal` for malformed literals
- Scopes for `operator`/`precedencegroup`
- Improvements to function parameter lists
- Improvements to generic parameter lists
- More thorough support for `class/struct/enum` definitions (scopes!), with generic params and constraints, and inheritance/conformance clauses
- Support for conditional compilation blocks (`#if/#elseif/#endif`) and platform checks supported therein

Resolves #20.

cc @infininight, @natecook1000, @sorbits

<img width="589" alt="screen shot 2016-08-28 at 2 02 03 am" src="https://cloud.githubusercontent.com/assets/14237/18032712/780fd53a-6cc3-11e6-8506-6bc85a2dec04.png">

```swift
#if os(macOS) && swift(>=3.0) && !arch(arm64)
import AppKit
#elseif false
Don't even think about parsing this
#endif

// Swift 2 stuff
infix operator ++ { associativity left precedence 10 assignment }
class Foo<Wrapped where Wrapped: SequenceType>: Bar<String, (Int, Any)>, Baz {
  func foo<T where Wrapped.Generator.Element == T>(x y: Int)
    rethrows -> (@escaping () -> Self) -> Int {}
  
  init?<T where T == T>(param: protocol<Foo, Bar>) throws {}
}
@noreturn func bar(arg: Int = __LINE__) {
  [0x1p+2 ... 0b42 + 0x1.5].map { self.foo($0) }
  fatalError()
}

// Swift 3 stuff
typealias Foo<K> = AnySequence<K> where K: Sequence

infix operator ++ : ExamplePrecedence
precedencegroup ExamplePrecedence {
  higherThan: LogicalConjunctionPrecedence
  lowerThan: ExponentiationPrecedence
  associativity: left
  assignment: true
}

class Foo<Wrapped>: Bar<String, (Int, Any)>, Baz where Wrapped: SequenceType { 
  func foo<T>(x y: Int) rethrows -> (@escaping () -> Self) -> Int
    where Wrapped.Iterator.Element == T {}
  
  init?<T>(param: Foo & Bar) throws where T == T {}
}
func bar(arg: Int = #line) throws -> Never { fatalError() }

/**/ func thisIsNotAComment() {}
```