### PR TITLE
Use a more GitHub-friendly pattern for hexadecimal chars

### DIFF
--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -4106,7 +4106,7 @@
 							<key>comment</key>
 							<string>-0x1.ap2_3, 0x31p-4</string>
 							<key>match</key>
-							<string>(\B\-|\b)(?&lt;![\[\](){}\p{L}_\p{N}\p{M}]\.)(0x\h[\h_]*)(?:\.\h[\h_]*)?[pP][-+]?[0-9][0-9_]*\b(?!\.[0-9])</string>
+							<string>(\B\-|\b)(?&lt;![\[\](){}\p{L}_\p{N}\p{M}]\.)(0x[0-9a-fA-F][0-9a-fA-F_]*)(?:\.[0-9a-fA-F][0-9a-fA-F_]*)?[pP][-+]?[0-9][0-9_]*\b(?!\.[0-9])</string>
 							<key>name</key>
 							<string>constant.numeric.float.hexadecimal.swift</string>
 						</dict>
@@ -4114,7 +4114,7 @@
 							<key>comment</key>
 							<string>0x1p, 0x1p_2, 0x1.5pa, 0x1.1p+1f, 0x1pz</string>
 							<key>match</key>
-							<string>(\B\-|\b)(?&lt;![\[\](){}\p{L}_\p{N}\p{M}]\.)(0x\h[\h_]*)(?:\.\h[\h_]*)?(?:[pP][-+]?\w*)\b(?!\.[0-9])</string>
+							<string>(\B\-|\b)(?&lt;![\[\](){}\p{L}_\p{N}\p{M}]\.)(0x[0-9a-fA-F][0-9a-fA-F_]*)(?:\.[0-9a-fA-F][0-9a-fA-F_]*)?(?:[pP][-+]?\w*)\b(?!\.[0-9])</string>
 							<key>name</key>
 							<string>invalid.illegal.numeric.float.invalid-exponent.swift</string>
 						</dict>
@@ -4122,7 +4122,7 @@
 							<key>comment</key>
 							<string>0x1.5w (note that 0x1.f may be a valid expression)</string>
 							<key>match</key>
-							<string>(\B\-|\b)(?&lt;![\[\](){}\p{L}_\p{N}\p{M}]\.)(0x\h[\h_]*)\.[0-9][\w.]*</string>
+							<string>(\B\-|\b)(?&lt;![\[\](){}\p{L}_\p{N}\p{M}]\.)(0x[0-9a-fA-F][0-9a-fA-F_]*)\.[0-9][\w.]*</string>
 							<key>name</key>
 							<string>invalid.illegal.numeric.float.missing-exponent.swift</string>
 						</dict>
@@ -4138,7 +4138,7 @@
 							<key>comment</key>
 							<string>0b_0_1, 0x_1p+3q</string>
 							<key>match</key>
-							<string>(\B\-|\b)0[box]_[\h_]*(?:[pPeE][+-]?\w+)?[\w.]+</string>
+							<string>(\B\-|\b)0[box]_[0-9a-fA-F_]*(?:[pPeE][+-]?\w+)?[\w.]+</string>
 							<key>name</key>
 							<string>invalid.illegal.numeric.leading-underscore.swift</string>
 						</dict>
@@ -4176,7 +4176,7 @@
 							<key>comment</key>
 							<string>0x4, 0xF_7</string>
 							<key>match</key>
-							<string>(\B\-|\b)(?&lt;![\[\](){}\p{L}_\p{N}\p{M}]\.)0x\h[\h_]*\b(?!\.[0-9])</string>
+							<string>(\B\-|\b)(?&lt;![\[\](){}\p{L}_\p{N}\p{M}]\.)0x[0-9a-fA-F][0-9a-fA-F_]*\b(?!\.[0-9])</string>
 							<key>name</key>
 							<string>constant.numeric.integer.hexadecimal.swift</string>
 						</dict>
@@ -4231,7 +4231,7 @@
 								</dict>
 								<dict>
 									<key>match</key>
-									<string>\\u\{\h{1,8}\}</string>
+									<string>\\u\{[0-9a-fA-F]{1,8}\}</string>
 									<key>name</key>
 									<string>constant.character.escape.unicode.swift</string>
 								</dict>


### PR DESCRIPTION
It seems GitHub does not support `\h`, so for example this is highlighted as invalid today:

```swift
0x42
```