### PR TITLE
Inheritance and other fixes

### DIFF
--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -3640,7 +3640,7 @@
 					<key>match</key>
 					<string>\$[0-9]+</string>
 					<key>name</key>
-					<string>variable.other.closure-parameter.swift</string>
+					<string>variable.language.closure-parameter.swift</string>
 				</dict>
 				<key>compound-name</key>
 				<dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>comment</key>
+	<string>See swift.tmbundle/grammar-test.swift for test cases.</string>
 	<key>fileTypes</key>
 	<array>
 		<string>swift</string>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -1804,7 +1804,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(?!\G)\n|(?=[&gt;{};\n])</string>
+					<string>(?!\G)$|(?=[&gt;{};\n])</string>
 					<key>name</key>
 					<string>meta.generic-where-clause.swift</string>
 					<key>patterns</key>
@@ -2066,27 +2066,101 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(?!\G)\n|(?=[={}]|(?!\G)\bwhere\b)</string>
+					<string>(?!\G)$|(?=[={}]|(?!\G)\bwhere\b)</string>
 					<key>name</key>
 					<string>meta.inheritance-clause.swift</string>
 					<key>patterns</key>
 					<array>
 						<dict>
 							<key>begin</key>
+							<string>\bclass\b</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>storage.type.class.swift</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>(?=[={}]|(?!\G)\bwhere\b)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#comments</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#more-types</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>begin</key>
 							<string>\G</string>
 							<key>end</key>
-							<string>(?!\G)\n|(?=[={}]|(?!\G)\bwhere\b)</string>
+							<string>(?!\G)$|(?=[={}]|(?!\G)\bwhere\b)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#comments</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#inherited-type</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#more-types</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
+					<key>repository</key>
+					<dict>
+						<key>inherited-type</key>
+						<dict>
+							<key>begin</key>
+							<string>(?=[`\p{L}_])</string>
+							<key>end</key>
+							<string>(?!\G)</string>
 							<key>name</key>
 							<string>entity.other.inherited-class.swift</string>
 							<key>patterns</key>
 							<array>
 								<dict>
 									<key>include</key>
-									<string>#available-types</string>
+									<string>#type-identifier</string>
 								</dict>
 							</array>
 						</dict>
-					</array>
+						<key>more-types</key>
+						<dict>
+							<key>begin</key>
+							<string>,\s*</string>
+							<key>end</key>
+							<string>(?!\G)(?!//|/\*)|(?=[,={}]|(?!\G)\bwhere\b)</string>
+							<key>name</key>
+							<string>meta.inheritance-list.more-types</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#comments</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#inherited-type</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#more-types</string>
+								</dict>
+							</array>
+						</dict>
+					</dict>
 				</dict>
 				<key>operator</key>
 				<dict>
@@ -2626,6 +2700,12 @@
 							<string>#inheritance-clause</string>
 						</dict>
 						<dict>
+							<key>comment</key>
+							<string>SE-0142: Permit where clauses to constrain associated types</string>
+							<key>include</key>
+							<string>#generic-where-clause</string>
+						</dict>
+						<dict>
 							<key>begin</key>
 							<string>\{</string>
 							<key>beginCaptures</key>
@@ -2695,7 +2775,7 @@
 								</dict>
 							</dict>
 							<key>end</key>
-							<string>(?!\G)\n|(?=[;}]|$)</string>
+							<string>(?!\G)$|(?=[;}]|$)</string>
 							<key>name</key>
 							<string>meta.definition.associatedtype.swift</string>
 							<key>patterns</key>
@@ -3265,40 +3345,40 @@
 				</dict>
 				<key>type-identifier</key>
 				<dict>
+					<key>begin</key>
+					<string>((?&lt;q&gt;`?)[\p{L}_][\p{L}_\p{N}\p{M}]*(\k&lt;q&gt;))\s*</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>meta.type-name.swift</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#builtin-types</string>
+								</dict>
+							</array>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.identifier.swift</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.identifier.swift</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(?!&lt;)</string>
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>captures</key>
-							<dict>
-								<key>0</key>
-								<dict>
-									<key>patterns</key>
-									<array>
-										<dict>
-											<key>include</key>
-											<string>#builtin-types</string>
-										</dict>
-									</array>
-								</dict>
-								<key>1</key>
-								<dict>
-									<key>name</key>
-									<string>punctuation.definition.identifier.swift</string>
-								</dict>
-								<key>2</key>
-								<dict>
-									<key>name</key>
-									<string>punctuation.definition.identifier.swift</string>
-								</dict>
-							</dict>
-							<key>match</key>
-							<string>(?&lt;q&gt;`?)[\p{L}_][\p{L}_\p{N}\p{M}]*(\k&lt;q&gt;)</string>
-							<key>name</key>
-							<string>meta.type-name.swift</string>
-						</dict>
-						<dict>
 							<key>begin</key>
-							<string>(?!\G)(?=&lt;)</string>
+							<string>(?=&lt;)</string>
 							<key>end</key>
 							<string>(?!\G)</string>
 							<key>patterns</key>
@@ -3339,7 +3419,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(?!\G)\n|(?=;|//|/\*|$)</string>
+					<string>(?!\G)$|(?=;|//|/\*|$)</string>
 					<key>name</key>
 					<string>meta.definition.typealias.swift</string>
 					<key>patterns</key>
@@ -3376,7 +3456,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(?!\G)\n|(?=;|//|/\*|$)</string>
+					<string>(?!\G)$|(?=;|//|/\*|$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -2385,12 +2385,12 @@
 								<key>1</key>
 								<dict>
 									<key>name</key>
-									<string>entity.name.function.swift</string>
+									<string>variable.parameter.function.swift</string>
 								</dict>
 								<key>2</key>
 								<dict>
 									<key>name</key>
-									<string>variable.parameter.function.swift</string>
+									<string>entity.name.function.swift</string>
 								</dict>
 								<key>3</key>
 								<dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -3339,14 +3339,23 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(?!\G)\n|(?=;|$)</string>
+					<string>(?!\G)\n|(?=;|//|/\*|$)</string>
 					<key>name</key>
 					<string>meta.definition.typealias.swift</string>
 					<key>patterns</key>
 					<array>
 						<dict>
-							<key>include</key>
-							<string>#generic-parameter-clause</string>
+							<key>begin</key>
+							<string>\G(?=&lt;)</string>
+							<key>end</key>
+							<string>(?!\G)</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#generic-parameter-clause</string>
+								</dict>
+							</array>
 						</dict>
 						<dict>
 							<key>include</key>
@@ -3367,7 +3376,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(?!\G)</string>
+					<string>(?!\G)\n|(?=;|//|/\*|$)</string>
 					<key>patterns</key>
 					<array>
 						<dict>

--- a/grammar-test.swift
+++ b/grammar-test.swift
@@ -1,0 +1,205 @@
+#!/usr/bin/swift
+// a comment
+/* a block comment */noLongerAComment()
+/*/ still just a block comment */noLongerAComment()
+/**/thatWasATinyBlockComment()
+/* block comments /* can be nested, */ like this! */noLongerAComment()
+
+import Foo
+import Foo.Submodule
+import func Foo.Submodule.`func`
+import func Control.Monad.>>=
+
+// MARK: Conditional compilation / compiler directives
+
+#if false // a comment
+  This is not code.
+#elseif false // a comment
+  This isn't either.
+#else // a comment
+  thisIsCode() // a comment
+#elseif os(macOS) || os(Linux) || foo_flag || arch(x86_64) && 1+2 && swift(>=4.2.6) //a comment
+#endif
+#sourceLocation(file: "foo", line: 123) // a comment
+if #available(macOS 10.12, iOS 9.1.2, *) {}
+#selector(MyClass.func)
+#selector(getter: MyClass.func) #selector(setter: MyClass.func)
+#keyPath(self.parent.name)
+#colorLiteral(), #imageLiteral(), #fileLiteral()
+#file, #line, #function, #dsohandle
+__FILE__, __LINE__, __FUNCTION__, __DSO_HANDLE__
+
+// MARK: Attributes
+
+@available(
+  macOS 1.2, macOSApplicationExtension 1.2, OSX, tvOS 1.4, iOS, watchOS,
+  introduced, introduced: 1,
+  deprecated, deprecated: 1,
+  obsoleted, obsoleted: 1,
+  message, message: "don't use this",
+  renamed, renamed: "somethingElse",
+  *, unavailable: no args)
+
+@objc(thisIs:aSelector:) @objc(forgotAColon:afterThis)
+@arbitraryAttr(with args)
+
+
+// MARK: Builtins
+
+x.dropFirst, x.dropFirst(3), x.dropFirst { /* no closure param */ }
+x.contains, x.contains(y), x.contains { $0 == y }
+autoreleasepool { }
+withExtendedLifetime { /* requires an arg */ }
+withExtendedLifetime(x) { }
+Process.foo, Process.argc, Process.unsafeArgv, Foo.argc
+obj+startIndex, obj.startIndex
+func foo() -> Never { fatalError() }
+
+// MARK: Types
+
+func foo(
+  builtin: Int, x: String, x: Sequence,
+  optional: Int!, x: Int?, x: Int!?!,
+  collection: Int, x: [Int], x: [Int: String], x: [Int: String: Invalid],
+  tuple: (Int, [Int], [Int: String], [Int: String: Invalid]),
+  boundGeneric: Any<Int, String, (Int, Never)>, differsFrom invalid: Int, String,
+  function: Int -> Void, x: (Int) throws -> String, x: (@escaping (Int) throws -> Void) rethrows -> Int,
+  writeback: inout Int,
+  variadic: Int...,
+  composition: Sequence & Collection, oldStyle: protocol<Sequence, Collection>,
+  metatype: Foo.Type, x: Foo.Protocol
+){}
+
+// MARK: Type definitions
+
+struct Foo { }
+class Foo { }
+class Foo: Bar { }
+class Foo<T where T: Equatable>: Bar { }
+class Foo<T>: Bar where T: Equatable { }
+class `var` {}
+class var x: Int
+
+protocol Foo {
+  associatedtype T: Equatable
+  associatedtype T = Int
+  associatedtype T: Equatable = Int
+  func functionBodyNotAllowedHere<T>() throws -> Int {}
+}
+protocol Foo: Equatable {}
+protocol Foo: Equatable, Indexable {}
+protocol Foo: class, Equatable {}
+protocol SE0142 : Sequence where Iterator.Element == Int { associatedtype Foo }
+protocol SE0142 {
+  associatedtype Iterator : IteratorProtocol
+  associatedtype SubSequence : Sequence where SubSequence.Iterator.Element == Iterator.Element
+}
+
+enum Foo {
+  case foo
+  case foo, bar baz
+  case foo,
+  bar
+  case foo(Int), bar(val: Int, labelNotAllowed val2: Int), baz(val: Int)
+  indirect case foo
+  case rawValue = 42, xx = "str", xx = true, xx = [too, complex], xx
+}
+
+typealias Foo = Bar
+typealias Foo<T> = Bar<T, Int> // comment
+
+// MARK: Extensions
+
+extension T {}
+extension String {}
+extension Array: Equatable {}
+extension Array where Element: Equatable, Foo == Int {}
+extension Array: Equatable, Foo where Element: Equatable, Foo == Int {}
+
+// MARK: Functions
+
+func something(
+  _ unlabeledArg: Int,
+  label separateFromInternalName: Int,
+  labelSameAsInternalName: Int
+  missed: a comma,
+  foo: bar,
+){}
+func foo() -> Int {}
+func foo() throws -> (Int, String) {}
+func foo() rethrows {}
+func +++(arg: Int) {}
+func `func`(arg: Int){}
+func generic<T>(arg: Int){}
+func ++<T>(arg: Int){}
+func < <T>(arg: Int){}
+func  <<T>(arg: Int){}
+func <+<<T>(arg: Int){}
+
+init(arg: Value) {}
+init<T>(arg: Value) {}
+
+func generic<A, B, C>() {}
+func generic<OldStyle where T: Equatable>(arg: Int) throws -> Int {}
+func generic<NewStyle>(arg: Int) throws -> Int where T: Equatable, T == Int {}
+
+// MARK: Operators
+
+x+y, x++y, x +++ y
+x...y  // TODO: probably shouldn't be variable
+x..<y
+x<<.y  // not a dot operator
+x?.y, x!.y
+
+// old style
+infix operator *.* { associativity left precedence 100 assignment }
+// new style
+infix operator *.* : AssignmentPrecedence { invalid }
+precedencegroup ExamplePrecedence {
+  higherThan: LogicalConjunctionPrecedence
+  lowerThan: SomeOtherPrecedence
+  associativity: left assignment: true
+}
+
+// MARK: Other expressions
+
+compoundFunctionName(_:arg1:arg2:), #selector(foo(bar:))
+functionCall(arg1: "stuff", labels notRecognized: "stuff")
+let tuple = (arg1: "stuff", labels notRecognized: "stuff")
+subscriptCall[arg1: "stuff", labels notRecognized: "stuff"]
+
+foo(a ?  b : c)
+foo(a ?, b : c)
+foo(flag ? foo as Bar : nil)
+foo(flag ? foo : nil, bar: nil)
+foo(
+  flag ?
+  foo :
+  nil,
+  bar: nil
+)
+foo(
+  flag
+  ? foo
+  : nil,
+  bar: nil
+)
+
+0.1, -4_2.5, 6.022e23, 10E-5
+-0x1.ap2_3, 0x31p-4
+0b010, 0b1_0
+0o1, 0o7_3
+02, 3_456
+0x4, 0xF_7
+0x1p, 0x1p_2, 0x1.5pa, 0x1.1p+1f, 0x1pz, 0x1.5w
+0x1.f, 0x1.property
+-.5, .2f
+1.-.5
+0b_0_1, 0x_1p+3q
+tuple.0, tuple.42
+0b12.5, 0xG
+
+"string \(interpolation)"
+"string \(1 + foo(x: 4))"
+
+associatedtype, class, deinit, enum, extension, func, import, init, inout, let, operator, $123, precedencegroup, protocol, struct, subscript, typealias, var, fileprivate, internal, private, public, static, defer, if, guard, do, repeat, else, for, in, while, return, break, continue, as?, fallthrough, switch, case, default, where, catch, as, Any, false, is, nil, rethrows, super, self, Self, throw, true, try, throws, nil


### PR DESCRIPTION
These changes address the following cases:

``` swift
func foo(bar: T)  // GitHub will color `bar` properly if we swap the order of its two scopes

typealias Foo<T> = Bar<T, Int>  // right-hand side are generic params, not variables; also comments should be allowed here

protocol P: class { }  // support class-requirement

// allow protocols to use associated types in where clauses <https://github.com/apple/swift-evolution/blob/master/proposals/0142-associated-types-constraints.md>
protocol IntSequence : Sequence where Iterator.Element == Int { }

class C: A, B { }  // make inheritance matching more intelligent so the comma isn't entity.other.inherited-class

// use $ instead of \n so the following are both matched properly
protocol A {
  associatedtype Iterator : IteratorProtocol
  associatedtype SubSequence : Sequence where SubSequence.Iterator.Element == Iterator.Element
}
```
