### PR TITLE
Minor fixes for string interpolation, where, and protocols

### DIFF
--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -2040,9 +2040,9 @@
 								</dict>
 								<dict>
 									<key>begin</key>
-									<string>(?!;|$|//|/\*)</string>
+									<string>(?!\s*(;|$|//|/\*))</string>
 									<key>end</key>
-									<string>(?=;|$|//|/\*)</string>
+									<string>(?=\s*(;|$|//|/\*))</string>
 									<key>name</key>
 									<string>invalid.illegal.character-not-allowed-here.swift</string>
 								</dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -1806,7 +1806,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(?!\G)$|(?=[&gt;{};\n])</string>
+					<string>(?!\G)$|(?=[&gt;{};\n]|//|/\*)</string>
 					<key>name</key>
 					<string>meta.generic-where-clause.swift</string>
 					<key>patterns</key>
@@ -1827,7 +1827,7 @@
 							<key>begin</key>
 							<string>\G|,\s*</string>
 							<key>end</key>
-							<string>(?=[,&gt;{};\n])</string>
+							<string>(?=[,&gt;{};\n]|//|/\*)</string>
 							<key>patterns</key>
 							<array>
 								<dict>
@@ -1854,7 +1854,7 @@
 										</dict>
 									</dict>
 									<key>end</key>
-									<string>(?=\s*[,&gt;{};\n])</string>
+									<string>(?=\s*[,&gt;{};\n]|//|/\*)</string>
 									<key>name</key>
 									<string>meta.generic-where-clause.same-type-requirement.swift</string>
 									<key>patterns</key>
@@ -1877,7 +1877,7 @@
 										</dict>
 									</dict>
 									<key>end</key>
-									<string>(?=\s*[,&gt;{};\n])</string>
+									<string>(?=\s*[,&gt;{};\n]|//|/\*)</string>
 									<key>name</key>
 									<string>meta.generic-where-clause.conformance-requirement.swift</string>
 									<key>patterns</key>
@@ -1888,7 +1888,7 @@
 											<key>contentName</key>
 											<string>entity.other.inherited-class.swift</string>
 											<key>end</key>
-											<string>(?=\s*[,&gt;{};\n])</string>
+											<string>(?=\s*[,&gt;{};\n]|//|/\*)</string>
 											<key>patterns</key>
 											<array>
 												<dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -2738,6 +2738,10 @@
 								</dict>
 								<dict>
 									<key>include</key>
+									<string>#protocol-initializer</string>
+								</dict>
+								<dict>
+									<key>include</key>
 									<string>#associated-type</string>
 								</dict>
 								<dict>
@@ -2795,6 +2799,90 @@
 								<dict>
 									<key>include</key>
 									<string>#typealias-assignment</string>
+								</dict>
+							</array>
+						</dict>
+						<key>protocol-initializer</key>
+						<dict>
+							<key>begin</key>
+							<string>(?&lt;!\.)\b(init[?!]*(?# only one is valid, but we want the in⇥ snippet to produce something that looks good))\s*(?=\(|&lt;)</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>storage.type.function.swift</string>
+									<key>patterns</key>
+									<array>
+										<dict>
+											<key>match</key>
+											<string>(?&lt;=[?!])[?!]+</string>
+											<key>name</key>
+											<string>invalid.illegal.character-not-allowed-here.swift</string>
+										</dict>
+									</array>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>$|(?=;|//|/\*|\})</string>
+							<key>name</key>
+							<string>meta.definition.function.initializer.swift</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>include</key>
+									<string>#comments</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#generic-parameter-clause</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#parameter-clause</string>
+								</dict>
+								<dict>
+									<key>match</key>
+									<string>\b(?:throws|rethrows)\b</string>
+									<key>name</key>
+									<string>keyword.control.exception.swift</string>
+								</dict>
+								<dict>
+									<key>comment</key>
+									<string>Swift 3: generic constraints after the parameters and return type</string>
+									<key>include</key>
+									<string>#generic-where-clause</string>
+								</dict>
+								<dict>
+									<key>begin</key>
+									<string>\{</string>
+									<key>beginCaptures</key>
+									<dict>
+										<key>0</key>
+										<dict>
+											<key>name</key>
+											<string>punctuation.section.function.begin.swift</string>
+										</dict>
+									</dict>
+									<key>end</key>
+									<string>\}</string>
+									<key>endCaptures</key>
+									<dict>
+										<key>0</key>
+										<dict>
+											<key>name</key>
+											<string>punctuation.section.function.end.swift</string>
+										</dict>
+									</dict>
+									<key>name</key>
+									<string>invalid.illegal.function-body-not-allowed-in-protocol.swift</string>
+									<key>patterns</key>
+									<array>
+										<dict>
+											<key>include</key>
+											<string>$self</string>
+										</dict>
+									</array>
 								</dict>
 							</array>
 						</dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -4327,56 +4327,50 @@
 									<string>constant.character.escape.unicode.swift</string>
 								</dict>
 								<dict>
-									<key>captures</key>
+									<key>begin</key>
+									<string>\\\(</string>
+									<key>beginCaptures</key>
 									<dict>
-										<key>1</key>
+										<key>0</key>
 										<dict>
 											<key>name</key>
 											<string>punctuation.section.embedded.begin.swift</string>
 										</dict>
-										<key>2</key>
-										<dict>
-											<key>name</key>
-											<string>source.swift</string>
-											<key>patterns</key>
-											<array>
-												<dict>
-													<key>include</key>
-													<string>#root</string>
-												</dict>
-											</array>
-										</dict>
-										<key>5</key>
+									</dict>
+									<key>contentName</key>
+									<string>source.swift</string>
+									<key>end</key>
+									<string>(\))</string>
+									<key>endCaptures</key>
+									<dict>
+										<key>0</key>
 										<dict>
 											<key>name</key>
 											<string>punctuation.section.embedded.end.swift</string>
 										</dict>
-										<key>6</key>
+										<key>1</key>
 										<dict>
 											<key>name</key>
 											<string>source.swift</string>
 										</dict>
 									</dict>
-									<key>match</key>
-									<string>(?x)
-										(\\\()							# Opening
-										(
-											(?&lt;parens&gt;
-												(
-													[^()"]				# Anything except parens
-												  | \(					# Matched pairs of parens
-													\g&lt;parens&gt;			#  …that can be nested
-													\)
-												  | "					# Strings
-													([^\\]|\\.)*		# Contents allowing for escapes
-													"
-												)*
-											)
-										)
-										((\)))							# Closing
-									</string>
 									<key>name</key>
 									<string>meta.embedded.line.swift</string>
+									<key>patterns</key>
+									<array>
+										<dict>
+											<key>include</key>
+											<string>$self</string>
+										</dict>
+										<dict>
+											<key>begin</key>
+											<string>\(</string>
+											<key>comment</key>
+											<string>Nested parens</string>
+											<key>end</key>
+											<string>\)</string>
+										</dict>
+									</array>
 								</dict>
 								<dict>
 									<key>match</key>

--- a/grammar-test.swift
+++ b/grammar-test.swift
@@ -208,4 +208,9 @@ tuple.0, tuple.42
 "nested: \(1+"string"+2)"
 print("nested: \(1+"string"+2)")
 
-associatedtype, class, deinit, enum, extension, func, import, init, inout, let, operator, $123, precedencegroup, protocol, struct, subscript, typealias, var, fileprivate, internal, private, public, static, defer, if, guard, do, repeat, else, for, in, while, return, break, continue, as?, fallthrough, switch, case, default, where, catch, as, Any, false, is, nil, rethrows, super, self, Self, throw, true, try, throws, nil
+associatedtype, class, deinit, enum, extension, func, import, init, inout,
+let, operator, $123, precedencegroup, protocol, struct, subscript, typealias,
+var, fileprivate, internal, private, public, static, defer, if, guard, do,
+repeat, else, for, in, while, return, break, continue, as?, fallthrough,
+switch, case, default, where, catch, as, Any, false, is, nil, rethrows,
+super, self, Self, throw, true, try, throws, nil

--- a/grammar-test.swift
+++ b/grammar-test.swift
@@ -84,6 +84,7 @@ protocol Foo {
   associatedtype T: Equatable
   associatedtype T = Int
   associatedtype T: Equatable = Int
+  func f<T: P3>(_: T) where T.A == Self.A, T.A: C // trailing comment still allows where to end
   func functionBodyNotAllowedHere<T>() throws -> Int {}
 }
 protocol Foo: Equatable {}

--- a/grammar-test.swift
+++ b/grammar-test.swift
@@ -86,6 +86,7 @@ protocol Foo {
   associatedtype T: Equatable = Int
   func f<T: P3>(_: T) where T.A == Self.A, T.A: C // trailing comment still allows where to end
   func functionBodyNotAllowedHere<T>() throws -> Int {}
+  init(norHere: Int) throws {}
 }
 protocol Foo: Equatable {}
 protocol Foo: Equatable, Indexable {}
@@ -95,6 +96,8 @@ protocol SE0142 {
   associatedtype Iterator : IteratorProtocol
   associatedtype SubSequence : Sequence where SubSequence.Iterator.Element == Iterator.Element
 }
+protocol Foo { init(x: Int) }
+func bar() { /* this is valid */ }
 
 enum Foo {
   case foo

--- a/grammar-test.swift
+++ b/grammar-test.swift
@@ -201,5 +201,7 @@ tuple.0, tuple.42
 
 "string \(interpolation)"
 "string \(1 + foo(x: 4))"
+"nested: \(1+"string"+2)"
+print("nested: \(1+"string"+2)")
 
 associatedtype, class, deinit, enum, extension, func, import, init, inout, let, operator, $123, precedencegroup, protocol, struct, subscript, typealias, var, fileprivate, internal, private, public, static, defer, if, guard, do, repeat, else, for, in, while, return, break, continue, as?, fallthrough, switch, case, default, where, catch, as, Any, false, is, nil, rethrows, super, self, Self, throw, true, try, throws, nil

--- a/grammar-test.swift
+++ b/grammar-test.swift
@@ -5,7 +5,7 @@
 /**/thatWasATinyBlockComment()
 /* block comments /* can be nested, */ like this! */noLongerAComment()
 
-import Foo
+import Foo   // whitespace ok
 import Foo.Submodule
 import func Foo.Submodule.`func`
 import func Control.Monad.>>=


### PR DESCRIPTION
Addresses the following issues:

```swift
import Foo   // trailing whitespace ok
```

```swift
func f<T: P3>(_: T) where T.A == Self.A // trailing comment should still allow 'where' to end
func thisIsAFunctionDecl() {}
```
```swift
protocol P { init() }
func notPartOfTheProtocol() { } // so a body should be allowed
```
```swift
print("nested: \(1+"string"+2)")
// this should not still be part of the string
```
(To solve the last one, I resurrected the begin/end patterns we previously had for string interpolation. Resolves #25. cc @revolter)