### PR TITLE
Add `import` snippet

### DIFF
--- a/Snippets/import.tmSnippet
+++ b/Snippets/import.tmSnippet
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>content</key>
+	<string>import ${1|Foundation,Cocoa,UIKit,CoreGraphics,WebKit|}</string>
+	<key>name</key>
+	<string>import</string>
+	<key>scope</key>
+	<string>source.swift</string>
+	<key>tabTrigger</key>
+	<string>im</string>
+	<key>uuid</key>
+	<string>E1CFACE6-1265-4053-B3D2-1A5701D8DD6C</string>
+</dict>
+</plist>

--- a/info.plist
+++ b/info.plist
@@ -21,6 +21,7 @@
 			<string>DDC4B4C0-5B7B-4CB2-AA3F-855F318A68FB</string>
 			<string>36D8B9E6-4FFE-41FD-AE6D-0A428CD59288</string>
 			<string>------------------------------------</string>
+			<string>E1CFACE6-1265-4053-B3D2-1A5701D8DD6C</string>
 			<string>92E5EDED-15A5-4E35-8F5D-CB2349532694</string>
 			<string>A3BCC521-F4E9-4CB3-BE78-6567C28CF791</string>
 			<string>76E0FE59-1693-4C35-91DE-999DF92C7AFF</string>


### PR DESCRIPTION
This adds a snippet to import modules into Swift code, tab trigger `im`.

This snippet hadn’t been dismissed in #18 but hasn’t been added by now,
so I’m proposing its addition separately.