### PR TITLE
Simplify lookbehind that was choking Atom and VS Code

### DIFF
--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -386,8 +386,10 @@
 			<key>patterns</key>
 			<array>
 				<dict>
+					<key>comment</key>
+					<string>The simpler (?&lt;=\bProcess\.|\bCommandLine\.) breaks VS Code / Atom, see https://github.com/textmate/swift.tmbundle/issues/29</string>
 					<key>match</key>
-					<string>(?&lt;=\bProcess\.|\bCommandLine\.)(arguments|argc|unsafeArgv)</string>
+					<string>(?&lt;=^Process\.|\WProcess\.|^CommandLine\.|\WCommandLine\.)(arguments|argc|unsafeArgv)</string>
 					<key>name</key>
 					<string>support.variable.swift</string>
 				</dict>


### PR DESCRIPTION
Addresses issue raised in #29.

@dominicap @svanimpe please try this out. I was able to verify the fix in VS Code, but my Atom installation is borked and I can't test very easily.