### PR TITLE
Support for raw/extended string literals

### DIFF
--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -4457,13 +4457,18 @@
 							<key>comment</key>
 							<string>SE-0168: Multi-Line String Literals</string>
 							<key>end</key>
-							<string>"""</string>
+							<string>"""(#*)</string>
 							<key>endCaptures</key>
 							<dict>
 								<key>0</key>
 								<dict>
 									<key>name</key>
 									<string>punctuation.definition.string.end.swift</string>
+								</dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>invalid.illegal.extra-closing-delimiter.swift</string>
 								</dict>
 							</dict>
 							<key>name</key>
@@ -4498,6 +4503,100 @@
 						</dict>
 						<dict>
 							<key>begin</key>
+							<string>#"""</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.string.begin.swift</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>"""#(#*)</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.string.end.swift</string>
+								</dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>invalid.illegal.extra-closing-delimiter.swift</string>
+								</dict>
+							</dict>
+							<key>name</key>
+							<string>string.quoted.double.block.raw.swift</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>match</key>
+									<string>\G.+(?=""")|\G.+</string>
+									<key>name</key>
+									<string>invalid.illegal.content-after-opening-delimiter.swift</string>
+								</dict>
+								<dict>
+									<key>match</key>
+									<string>\\#\s*\n</string>
+									<key>name</key>
+									<string>constant.character.escape.newline.swift</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#raw-string-guts</string>
+								</dict>
+								<dict>
+									<key>comment</key>
+									<string>Allow \("""...""") to appear inside a block string</string>
+									<key>match</key>
+									<string>\S((?!\\#\().)*(?=""")</string>
+									<key>name</key>
+									<string>invalid.illegal.content-before-closing-delimiter.swift</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>(##*)"""</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.string.begin.swift</string>
+								</dict>
+							</dict>
+							<key>end</key>
+							<string>"""\1(#*)</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.string.end.swift</string>
+								</dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>invalid.illegal.extra-closing-delimiter.swift</string>
+								</dict>
+							</dict>
+							<key>name</key>
+							<string>string.quoted.double.block.raw.swift</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>match</key>
+									<string>\G.+(?=""")|\G.+</string>
+									<key>name</key>
+									<string>invalid.illegal.content-after-opening-delimiter.swift</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>begin</key>
 							<string>"</string>
 							<key>beginCaptures</key>
 							<dict>
@@ -4508,13 +4607,18 @@
 								</dict>
 							</dict>
 							<key>end</key>
-							<string>"</string>
+							<string>"(#*)</string>
 							<key>endCaptures</key>
 							<dict>
 								<key>0</key>
 								<dict>
 									<key>name</key>
 									<string>punctuation.definition.string.end.swift</string>
+								</dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>invalid.illegal.extra-closing-delimiter.swift</string>
 								</dict>
 							</dict>
 							<key>name</key>
@@ -4533,9 +4637,165 @@
 								</dict>
 							</array>
 						</dict>
+						<dict>
+							<key>begin</key>
+							<string>(##+)"</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.string.begin.raw.swift</string>
+								</dict>
+							</dict>
+							<key>comment</key>
+							<string>SE-0168: raw string literals (more than one #, grammar limitations prevent us from supporting escapes)</string>
+							<key>end</key>
+							<string>"\1(#*)</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.string.end.raw.swift</string>
+								</dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>invalid.illegal.extra-closing-delimiter.swift</string>
+								</dict>
+							</dict>
+							<key>name</key>
+							<string>string.quoted.double.single-line.raw.swift</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>match</key>
+									<string>\r|\n</string>
+									<key>name</key>
+									<string>invalid.illegal.returns-not-allowed.swift</string>
+								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>begin</key>
+							<string>#"</string>
+							<key>beginCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.string.begin.raw.swift</string>
+								</dict>
+							</dict>
+							<key>comment</key>
+							<string>SE-0168: raw string literals (one #, escapes supported)</string>
+							<key>end</key>
+							<string>"#(#*)</string>
+							<key>endCaptures</key>
+							<dict>
+								<key>0</key>
+								<dict>
+									<key>name</key>
+									<string>punctuation.definition.string.end.raw.swift</string>
+								</dict>
+								<key>1</key>
+								<dict>
+									<key>name</key>
+									<string>invalid.illegal.extra-closing-delimiter.swift</string>
+								</dict>
+							</dict>
+							<key>name</key>
+							<string>string.quoted.double.single-line.raw.swift</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>match</key>
+									<string>\r|\n</string>
+									<key>name</key>
+									<string>invalid.illegal.returns-not-allowed.swift</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#raw-string-guts</string>
+								</dict>
+							</array>
+						</dict>
 					</array>
 					<key>repository</key>
 					<dict>
+						<key>raw-string-guts</key>
+						<dict>
+							<key>comment</key>
+							<string>the same as #string-guts but with # in escapes</string>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>match</key>
+									<string>\\#[0\\tnr"']</string>
+									<key>name</key>
+									<string>constant.character.escape.swift</string>
+								</dict>
+								<dict>
+									<key>match</key>
+									<string>\\#u\{[0-9a-fA-F]{1,8}\}</string>
+									<key>name</key>
+									<string>constant.character.escape.unicode.swift</string>
+								</dict>
+								<dict>
+									<key>begin</key>
+									<string>\\#\(</string>
+									<key>beginCaptures</key>
+									<dict>
+										<key>0</key>
+										<dict>
+											<key>name</key>
+											<string>punctuation.section.embedded.begin.swift</string>
+										</dict>
+									</dict>
+									<key>contentName</key>
+									<string>source.swift</string>
+									<key>end</key>
+									<string>(\))</string>
+									<key>endCaptures</key>
+									<dict>
+										<key>0</key>
+										<dict>
+											<key>name</key>
+											<string>punctuation.section.embedded.end.swift</string>
+										</dict>
+										<key>1</key>
+										<dict>
+											<key>name</key>
+											<string>source.swift</string>
+										</dict>
+									</dict>
+									<key>name</key>
+									<string>meta.embedded.line.swift</string>
+									<key>patterns</key>
+									<array>
+										<dict>
+											<key>include</key>
+											<string>$self</string>
+										</dict>
+										<dict>
+											<key>begin</key>
+											<string>\(</string>
+											<key>comment</key>
+											<string>Nested parens</string>
+											<key>end</key>
+											<string>\)</string>
+										</dict>
+									</array>
+								</dict>
+								<dict>
+									<key>match</key>
+									<string>\\#.</string>
+									<key>name</key>
+									<string>invalid.illegal.escape-not-recognized</string>
+								</dict>
+							</array>
+						</dict>
 						<key>string-guts</key>
 						<dict>
 							<key>patterns</key>

--- a/grammar-test.swift
+++ b/grammar-test.swift
@@ -206,16 +206,49 @@ foo(
 tuple.0, tuple.42
 0b12.5, 0xG
 
-"string \(interpolation)"
-"string \(1 + foo(x: 4))"
-"nested: \(1+"string"+2)"
-print("nested: \(1+"string"+2)")
+print("a\0b\nc\u{1}d \(interpolation) a \(1 + foo(x: 4)) nested: \(1+"string"+2) x"#)
+print(#"raw: a\0b\nc\u{1}d \(interpolation) a \(1 + foo(x: 4)) nested: \(1+"string"+2) x"##)
+print(#"raw: a\#0b\#nc\#u{1}d \#(interpolation) a \#(1 + foo(x: 4)) nested: \#(1+"string"+2) x"##)
+print(##"raw: a\#0b\#nc\#u{1}d \#(interpolation) a \#(1 + foo(x: 4)) nested: \#(1+"string"+2) x"###)
+print(##"raw: a\##0b\##nc\##u{1}d \##(interpolation) a \##(1 + foo(x: 4)) nested: \##(1+"string"+2) x"###)
+
+"invalid newline
+"
+#"invalid newline
+"#
+##"invalid newline
+"##
 
 let SE0168 = """   illegal
         my, what a large…
     \(1 + foo(x: 4))
+    \("""
+      more \( """
+        s
+      """)
+    """)
         …string you have!
     illegal"""
+let SE0168 = #"""   illegal
+        my, what a large…
+    \#(1 + foo(x: 4))
+    \#(#"""
+      more \#( #"""
+        s
+      """#)
+    """#)
+        …string you have!
+    illegal"""#
+let SE0168 = ##"""   illegal
+        my, what a large…
+    \#(1 + foo(x: 4))
+    \#(#"""
+      more \#( #"""
+        s
+      """#)
+    """#)
+        …string you have!
+    illegal"""##
 
 associatedtype, class, deinit, enum, extension, func, import, init, inout,
 let, operator, $123, precedencegroup, protocol, struct, subscript, typealias,


### PR DESCRIPTION
As discussed in #39, adds support for all escapes in a single `#"...\#n..."#` string, and limited support for raw strings with more `#`s due to grammar limitations. cc @erikstrottmann

@sorbits Please advise if there's any way to reduce grammar duplication more than I've been able to :)

![image](https://user-images.githubusercontent.com/14237/63492412-484d8f80-c46e-11e9-8375-b16cc1e3ac23.png)
