### PR TITLE
Treat `#if false` as a code, not a block comment

### DIFF
--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -806,37 +806,6 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>^\s*(#)(if|elseif)\s+(false)\b.*?(?=$|//|/\*)</string>
-					<key>beginCaptures</key>
-					<dict>
-						<key>0</key>
-						<dict>
-							<key>name</key>
-							<string>meta.preprocessor.conditional.swift</string>
-						</dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>punctuation.definition.preprocessor.swift</string>
-						</dict>
-						<key>2</key>
-						<dict>
-							<key>name</key>
-							<string>keyword.control.preprocessor.conditional.swift</string>
-						</dict>
-						<key>3</key>
-						<dict>
-							<key>name</key>
-							<string>constant.language.boolean.swift</string>
-						</dict>
-					</dict>
-					<key>contentName</key>
-					<string>comment.block.preprocessor.swift</string>
-					<key>end</key>
-					<string>(?=^\s*(#(elseif|else|endif)\b))</string>
-				</dict>
-				<dict>
-					<key>begin</key>
 					<string>^\s*(#)(if|elseif)\s+</string>
 					<key>captures</key>
 					<dict>


### PR DESCRIPTION
Hi maintainers,

Currently, the defined syntax treats the body inside `#if false` as a block comment, not code.
But I'd say it's code, because the Swift compiler does parse it and compilation fails if it's syntactically incorrect.
I confirmed this behavior with swiftc 3.1.1 and the latest with https://godbolt.org/z/TTNu_R.

As a pragmatic reason, I'm doing kind of the trunk-based development with my team where we tend to temporarily disable alpha features with `#if false` to merge them into master branch early. This change make reviewing them much easier on GitHub.

I'm happy to hear if there is any reason not to do this. Thanks!