### PR TITLE
Add #filePath to variables list

### DIFF
--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -4239,7 +4239,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\B(?:#file|#line|#column|#function|#dsohandle)\b|\b(?:__FILE__|__LINE__|__COLUMN__|__FUNCTION__|__DSO_HANDLE__)\b</string>
+					<string>\B(?:#file|#filePath|#line|#column|#function|#dsohandle)\b|\b(?:__FILE__|__FILE_NAME__|__LINE__|__COLUMN__|__FUNCTION__|__DSO_HANDLE__)\b</string>
 					<key>name</key>
 					<string>support.variable.swift</string>
 				</dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -4239,7 +4239,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\B(?:#file|#filePath|#line|#column|#function|#dsohandle)\b|\b(?:__FILE__|__FILE_NAME__|__LINE__|__COLUMN__|__FUNCTION__|__DSO_HANDLE__)\b</string>
+					<string>\B(?:#file|#filePath|#line|#column|#function|#dsohandle)\b|\b(?:__FILE__|__LINE__|__COLUMN__|__FUNCTION__|__DSO_HANDLE__)\b</string>
 					<key>name</key>
 					<string>support.variable.swift</string>
 				</dict>


### PR DESCRIPTION
This PR adds the new `#filePath` variable that was added in Swift 5.3. I noticed that GitHub doesn't syntax highlight it at all right now, so hopefully this should fix it.

Swift evolution proposal for reference: https://github.com/apple/swift-evolution/blob/master/proposals/0274-magic-file.md

I'm not sure if we should add `__FILE_NAME__` but the proposals mentions its existence at the bottom (even though it's rarely used), so I can remove it if you think it shouldn't be added.