### PR TITLE
Match opaque result types per SE-0244

### DIFF
--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -1184,6 +1184,10 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#typed-variable-declaration</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#import</string>
 				</dict>
 				<dict>
@@ -1234,6 +1238,12 @@
 							<string>\b(?:throws|rethrows)\b</string>
 							<key>name</key>
 							<string>keyword.control.exception.swift</string>
+						</dict>
+						<dict>
+							<key>match</key>
+							<string>\bsome\b</string>
+							<key>name</key>
+							<string>keyword.operator.type.opaque.swift</string>
 						</dict>
 						<dict>
 							<key>match</key>
@@ -3619,6 +3629,32 @@
 					</dict>
 					<key>end</key>
 					<string>(?!\G)$|(?=;|//|/\*|$)</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#available-types</string>
+						</dict>
+					</array>
+				</dict>
+				<key>typed-variable-declaration</key>
+				<dict>
+					<key>begin</key>
+					<string>(?x)
+						\b(let|var)\b\s+
+						(?&lt;q&gt;`?)[\p{L}_][\p{L}_\p{N}\p{M}]*(\k&lt;q&gt;)\s*
+						:
+					</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.declaration-specifier.swift</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(?=$|[={])</string>
 					<key>patterns</key>
 					<array>
 						<dict>

--- a/grammar-test.swift
+++ b/grammar-test.swift
@@ -74,8 +74,8 @@ func foo(
 
 func opaqueTypes() -> some View {}
 struct Foo {
-  let some: Int = 42
-  var body: some View {}
+  let some: Int? = .some(42)
+  var body: some View
 }
 
 // MARK: Type definitions

--- a/grammar-test.swift
+++ b/grammar-test.swift
@@ -72,6 +72,12 @@ func foo(
   metatype: Foo.Type, x: Foo.Protocol
 ){}
 
+func opaqueTypes() -> some View {}
+struct Foo {
+  let some: Int = 42
+  var body: some View {}
+}
+
 // MARK: Type definitions
 
 struct Foo { }


### PR DESCRIPTION
Documentation:
- https://docs.swift.org/swift-book/ReferenceManual/Types.html#ID616
- https://github.com/apple/swift-evolution/blob/master/proposals/0244-opaque-result-types.md

Opaque result types are used heavily in SwiftUI code, for example:
- https://github.com/ivanvorobei/SwiftUI
- https://github.com/apple-sample-code/SwiftUI-Tutorials

Since `some` is a keyword that pertains only to types, it can still be used as a regular variable name. So this PR adds a pattern for `let`/`var` declarations with types, so that the `some` pattern can be enabled only where appropriate.

<img src="https://user-images.githubusercontent.com/14237/99838685-5f21dc80-2b1e-11eb-96e9-c893c62aafbf.png" width="300">

```swift
func opaqueTypes() -> some View {}
struct Foo {
  let some: Int? = .some(42)
  var body: some View {}
}
```