### PR TITLE
Support for async/await, SE-0296

### DIFF
--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -23,6 +23,29 @@
 	</array>
 	<key>repository</key>
 	<dict>
+		<key>async-throws</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>invalid.illegal.await-must-precede-throws.swift</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.exception.swift</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.async.swift</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>\b(?:(throws\s+async|rethrows\s+async)|(throws|rethrows)|(async))\b</string>
+		</dict>
 		<key>attributes</key>
 		<dict>
 			<key>patterns</key>
@@ -1235,6 +1258,12 @@
 						</dict>
 						<dict>
 							<key>match</key>
+							<string>\basync\b</string>
+							<key>name</key>
+							<string>keyword.control.async.swift</string>
+						</dict>
+						<dict>
+							<key>match</key>
 							<string>\b(?:throws|rethrows)\b</string>
 							<key>name</key>
 							<string>keyword.control.exception.swift</string>
@@ -1594,10 +1623,8 @@
 							<string>#function-result</string>
 						</dict>
 						<dict>
-							<key>match</key>
-							<string>\b(?:throws|rethrows)\b</string>
-							<key>name</key>
-							<string>keyword.control.exception.swift</string>
+							<key>include</key>
+							<string>#async-throws</string>
 						</dict>
 						<dict>
 							<key>comment</key>
@@ -1678,10 +1705,8 @@
 							<string>#parameter-clause</string>
 						</dict>
 						<dict>
-							<key>match</key>
-							<string>\b(?:throws|rethrows)\b</string>
-							<key>name</key>
-							<string>keyword.control.exception.swift</string>
+							<key>include</key>
+							<string>#async-throws</string>
 						</dict>
 						<dict>
 							<key>comment</key>
@@ -2468,13 +2493,18 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(\))</string>
+					<string>(\))(?:\s*(async)\b)?</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.definition.parameters.end.swift</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.control.async.swift</string>
 						</dict>
 					</dict>
 					<key>name</key>
@@ -2917,10 +2947,8 @@
 									<string>#parameter-clause</string>
 								</dict>
 								<dict>
-									<key>match</key>
-									<string>\b(?:throws|rethrows)\b</string>
-									<key>name</key>
-									<string>keyword.control.exception.swift</string>
+									<key>include</key>
+									<string>#async-throws</string>
 								</dict>
 								<dict>
 									<key>comment</key>
@@ -3053,10 +3081,8 @@
 									<string>#function-result</string>
 								</dict>
 								<dict>
-									<key>match</key>
-									<string>\b(?:throws|rethrows)\b</string>
-									<key>name</key>
-									<string>keyword.control.exception.swift</string>
+									<key>include</key>
+									<string>#async-throws</string>
 								</dict>
 								<dict>
 									<key>comment</key>
@@ -4088,14 +4114,32 @@
 							<string>punctuation.section.tuple.begin.swift</string>
 						</dict>
 					</dict>
+					<key>comment</key>
+					<string>correctly matching closure expressions is too hard (depends on trailing "in") so we just tack on some basics to the end of parenthesized-expression</string>
 					<key>end</key>
-					<string>\)</string>
+					<string>(\))\s*((?:\b(?:async|throws|rethrows)\s)*)</string>
 					<key>endCaptures</key>
 					<dict>
-						<key>0</key>
+						<key>1</key>
 						<dict>
 							<key>name</key>
 							<string>punctuation.section.tuple.end.swift</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>patterns</key>
+							<array>
+								<dict>
+									<key>match</key>
+									<string>\brethrows\b</string>
+									<key>name</key>
+									<string>invalid.illegal.rethrows-only-allowed-on-function-declarations.swift</string>
+								</dict>
+								<dict>
+									<key>include</key>
+									<string>#async-throws</string>
+								</dict>
+							</array>
 						</dict>
 					</dict>
 					<key>patterns</key>
@@ -4186,6 +4230,23 @@
 					<string>(?&lt;!\.)\bdefer\b</string>
 					<key>name</key>
 					<string>keyword.control.defer.swift</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>invalid.illegal.try-must-precede-await.swift</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.control.await.swift</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(?&lt;!\.)\b(?:(await\s+try)|(await)\b)</string>
 				</dict>
 				<dict>
 					<key>match</key>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -4246,7 +4246,7 @@
 					<key>comment</key>
 					<string>matches weak, unowned, unowned(safe), unowned(unsafe)</string>
 					<key>match</key>
-					<string>(?&lt;!\.)\b(?:weak|unowned)\b|\bunowned\((?:safe|unsafe)\)</string>
+					<string>(?&lt;!\.)\bunowned\((?:safe|unsafe)\)|(?&lt;!\.)\b(?:weak|unowned)\b</string>
 					<key>name</key>
 					<string>keyword.other.capture-specifier.swift</string>
 				</dict>

--- a/grammar-test.swift
+++ b/grammar-test.swift
@@ -93,8 +93,9 @@ protocol Foo {
   associatedtype T = Int
   associatedtype T: Equatable = Int
   func f<T: P3>(_: T) where T.A == Self.A, T.A: C // trailing comment still allows where to end
-  func functionBodyNotAllowedHere<T>() throws -> Int {}
-  init(norHere: Int) throws {}
+  func functionBodyNotAllowedHere<T>() async throws -> Int {}
+  init(norHere: Int) async throws {}
+  init(norHere: Int) throws async {}
 }
 protocol Foo: Equatable {}
 protocol Foo: Equatable, Indexable {}
@@ -148,6 +149,34 @@ func ++<T>(arg: Int){}
 func < <T>(arg: Int){}
 func  <<T>(arg: Int){}
 func <+<<T>(arg: Int){}
+
+// MARK: async/await
+func foo() async {
+  let x = await y
+  let z = async  // async is only a contextual keyword
+  let newURL = await server.redirectURL(for: url)
+  let (data, response) = try await session.dataTask(with: newURL)
+  let (data, response) = await try session.dataTask(with: newURL) // not allowed
+  let (data, response) = await (try session.dataTask(with: newURL)) // ok
+}
+func foo() async -> Int {}
+func foo() async throws -> (Int, String) {}
+func foo() throws async -> (Int, String) {}
+func foo() async rethrows {}
+func foo() rethrows async {}
+init() throws async {}
+struct FunctionTypes {
+  var syncNonThrowing: () -> Void
+  var syncThrowing: () throws -> Void
+  var asyncNonThrowing: () async -> Void
+  var asyncThrowing: () async throws -> Void = x
+}
+let closure = { _ = await getInt() } // implicitly async
+let closure = { (x: Int) async -> Int in 42 } // explicitly async
+let closure = { (x: Int) throws -> Int in 42 }
+let closure = { (x: Int) rethrows -> Int in 42 }
+let closure = { (x: Int) async throws -> Int in 42 }
+let closure = { (x: Int) throws async -> Int in 42 }
 
 init(arg: Value) {}
 init<T>(arg: Value) {}


### PR DESCRIPTION
https://github.com/apple/swift-evolution/blob/main/proposals/0296-async-await.md

```swift
func foo() async {
  let x = await y
  let z = async  // async is only a contextual keyword
  let newURL = await server.redirectURL(for: url)
  let (data, response) = try await session.dataTask(with: newURL)
  let (data, response) = await try session.dataTask(with: newURL) // not allowed
  let (data, response) = await (try session.dataTask(with: newURL)) // ok
}
func foo() async -> Int {}
func foo() async throws -> (Int, String) {}
func foo() throws async -> (Int, String) {}
func foo() async rethrows {}
func foo() rethrows async {}
init() throws async {}
struct FunctionTypes {
  var syncNonThrowing: () -> Void
  var syncThrowing: () throws -> Void
  var asyncNonThrowing: () async -> Void
  var asyncThrowing: () async throws -> Void = x
}
let closure = { _ = await getInt() } // implicitly async
let closure = { (x: Int) async -> Int in 42 } // explicitly async
let closure = { (x: Int) throws -> Int in 42 }
let closure = { (x: Int) rethrows -> Int in 42 }
let closure = { (x: Int) async throws -> Int in 42 }
let closure = { (x: Int) throws async -> Int in 42 }
```

<img width="596" alt="image" src="https://user-images.githubusercontent.com/14237/107160450-e03d8280-695b-11eb-9f29-ee809cafcac6.png">
