### PR TITLE
Add support for `async let` syntax (SE-0317)

### DIFF
--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -3667,13 +3667,18 @@
 				<dict>
 					<key>begin</key>
 					<string>(?x)
-						\b(let|var)\b\s+
+						\b(?:(async)\b\s+)?(let|var)\b\s+
 						(?&lt;q&gt;`?)[\p{L}_][\p{L}_\p{N}\p{M}]*(\k&lt;q&gt;)\s*
 						:
 					</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.control.async.swift</string>
+						</dict>
+						<key>2</key>
 						<dict>
 							<key>name</key>
 							<string>keyword.other.declaration-specifier.swift</string>
@@ -4274,8 +4279,25 @@
 					<string>(?&lt;!\.)\b(do)\b(\s*)</string>
 				</dict>
 				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.control.async.swift</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.other.declaration-specifier.swift</string>
+						</dict>
+					</dict>
 					<key>match</key>
-					<string>(?&lt;!\.)\b(?:associatedtype|let|operator|typealias|var)\b</string>
+					<string>(?&lt;!\.)\b(?:(async)\b\s+)?(let|var)\b</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>(?&lt;!\.)\b(?:associatedtype|operator|typealias)\b</string>
 					<key>name</key>
 					<string>keyword.other.declaration-specifier.swift</string>
 				</dict>

--- a/Syntaxes/Swift.tmLanguage
+++ b/Syntaxes/Swift.tmLanguage
@@ -3667,7 +3667,7 @@
 				<dict>
 					<key>begin</key>
 					<string>(?x)
-						\b(?:(async)\b\s+)?(let|var)\b\s+
+						\b(?:(async)\s+)?(let|var)\b\s+
 						(?&lt;q&gt;`?)[\p{L}_][\p{L}_\p{N}\p{M}]*(\k&lt;q&gt;)\s*
 						:
 					</string>
@@ -4293,7 +4293,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?&lt;!\.)\b(?:(async)\b\s+)?(let|var)\b</string>
+					<string>(?&lt;!\.)\b(?:(async)\s+)?(let|var)\b</string>
 				</dict>
 				<dict>
 					<key>match</key>

--- a/grammar-test.swift
+++ b/grammar-test.swift
@@ -176,6 +176,10 @@ func foo() async {
   async let dog = getDoggo()
   async let pup: Dog = getDoggo()
 }
+callMe { // async closure
+  async let hello = greet()
+  return await hello
+}
 func foo() async -> Int {}
 func foo() async throws -> (Int, String) {}
 func foo() throws async -> (Int, String) {}

--- a/grammar-test.swift
+++ b/grammar-test.swift
@@ -173,6 +173,8 @@ func foo() async {
   let (data, response) = try await session.dataTask(with: newURL)
   let (data, response) = await try session.dataTask(with: newURL) // not allowed
   let (data, response) = await (try session.dataTask(with: newURL)) // ok
+  async let dog = getDoggo()
+  async let pup: Dog = getDoggo()
 }
 func foo() async -> Int {}
 func foo() async throws -> (Int, String) {}


### PR DESCRIPTION
See https://github.com/apple/swift-evolution/blob/main/proposals/0317-async-let.md

This also highlights `async var` although it's invalid (Xcode highlights it as well).